### PR TITLE
Fix storefront routes and content cleanup

### DIFF
--- a/public/assets/css/style.css
+++ b/public/assets/css/style.css
@@ -411,10 +411,13 @@ body.nav-hidden #navbar {
   margin-top:18px;
   width:100%;
   background:#000;
-  display:flex;
+  display:grid;
+  grid-template-columns: auto minmax(0, 1fr) auto;
   align-items:center;
   justify-content:center;
+  gap:14px;
   border:1px solid rgba(255,255,255,0.08);
+  padding:14px;
 }
 .lookbook-view img {
   width:100%;
@@ -423,6 +426,42 @@ body.nav-hidden #navbar {
   display:block;
   user-select:none;
   -webkit-user-drag:none;
+}
+
+
+.route-arrow {
+  width: 48px;
+  height: 48px;
+  border-radius: 999px;
+  border: 1px solid rgba(255,255,255,0.14);
+  background: rgba(255,255,255,0.04);
+  color: #fff;
+  font-size: 2rem;
+  line-height: 1;
+  cursor: pointer;
+}
+.route-arrow:disabled {
+  opacity: 0.35;
+  cursor: default;
+}
+.route-meta {
+  margin-top: 12px;
+  color: var(--muted);
+  text-align: center;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  font-size: 0.75rem;
+}
+@media (max-width:768px) {
+  .lookbook-view {
+    grid-template-columns: 1fr;
+  }
+  .route-arrow {
+    width: 100%;
+    height: 42px;
+    font-size: 1.5rem;
+  }
 }
 
 /* Product route */

--- a/public/assets/js/app.js
+++ b/public/assets/js/app.js
@@ -135,12 +135,26 @@ const qs = url.searchParams.toString();
 return qs ? url.pathname + "?" + qs : url.pathname;
 }
 
-function gotoLookbook(i) {
-window.location.href = toQueryUrl({ page: "lookbook", i });
+function navigateTo(params, { replace = false } = {}) {
+const target = toQueryUrl(params);
+if (replace) history.replaceState(params, "", target);
+else history.pushState(params, "", target);
+window.dispatchEvent(new CustomEvent("faide:navigate"));
 }
 
-function gotoProduct(id) {
-window.location.href = toQueryUrl({ page: "product", id });
+function gotoLookbook(i, options) {
+navigateTo({ page: "lookbook", i }, options);
+}
+
+function gotoProduct(id, options) {
+navigateTo({ page: "product", id }, options);
+}
+
+function gotoHomeSection(id = "drop", { replace = false } = {}) {
+const target = `${window.location.pathname}#${id}`;
+if (replace) history.replaceState({}, "", target);
+else history.pushState({}, "", target);
+window.dispatchEvent(new CustomEvent("faide:navigate"));
 }
 
 function showRoute(page) {
@@ -551,7 +565,7 @@ return { open, close, isOpen: () => overlay?.style.display === "block" };
 
 function formatPriceZAR(price) {
 const n = Number(price || 0);
-return R${n.toFixed(2)};
+return `R${n.toFixed(2)}`;
 }
 
 function renderLookbook(listEl, lookbookItems) {
@@ -562,8 +576,8 @@ const card = document.createElement("div");
 card.className = "lookbook-card";
 card.setAttribute("role", "button");
 card.setAttribute("tabindex", "0");
-card.setAttribute("aria-label", Open Lookbook ${item.id});
-card.innerHTML = <img src="${item.image}" alt="${item.alt || "Lookbook"}" class="lookbook-img" />;
+card.setAttribute("aria-label", `Open lookbook image ${item.id}`);
+card.innerHTML = `<img src="${item.image}" alt="${item.alt || "Lookbook"}" class="lookbook-img" />`;
 const go = () => gotoLookbook(String(item.id));
 card.addEventListener("click", go);
 clickOnEnterSpace(card, go);
@@ -964,27 +978,10 @@ bindProductCards();
 updateCartUI();  
 
 // ---------- Routes ----------  
-const params = new URLSearchParams(window.location.search);  
-const page = params.get("page");  
-
-// nav click behavior  
-navLinks.forEach((a) => {  
-  a.addEventListener("click", (e) => {  
-    const href = a.getAttribute("href") || "";  
-    if (!href.includes("#")) return;  
-    if (page === "lookbook" || page === "product") {  
-      e.preventDefault();  
-      window.location.href = "index.html" + href;  
-    } else {  
-      e.preventDefault();  
-      const id = href.replace("#", "");  
-      scrollToSectionId(id);  
-      history.replaceState(null, "", `${location.pathname}#${id}`);  
-    }  
-  });  
-});  
-
 const rlbImg = $("rlb-img");  
+const rlbPrev = $("rlb-prev");
+const rlbNext = $("rlb-next");
+const rlbMeta = $("rlb-meta");
 
 const rpp = {  
   img: $("rpp-img"),  
@@ -1001,14 +998,67 @@ const rpp = {
 
 const rppStepperRoot = document.querySelector('.qty-stepper-ui[data-qty-root="rpp"]');  
 const rppStepper = rppStepperRoot ? setupQtyStepper(rppStepperRoot) : null;  
+const sectionIds = ["drop", "lookbook", "shop", "about"];  
+const sections = sectionIds.map((id) => document.getElementById(id)).filter(Boolean);  
+let navLock = false;  
+let navUnlockTimer = null;  
+let raf = null;  
+let activeRoute = null;
+let activeLookbookIndex = 1;
+
+function setActive(id) {  
+  navLinks.forEach((a) => {  
+    a.classList.remove("active");  
+    a.removeAttribute("aria-current");  
+  });  
+  Array.from(navLinks)  
+    .filter((a) => (a.getAttribute("href") || "").endsWith(`#${id}`))  
+    .forEach((lnk) => {  
+      lnk.classList.add("active");  
+      lnk.setAttribute("aria-current", "page");  
+    });  
+}  
+
+const updateActiveFromScroll = () => {  
+  if (navLock || activeRoute) return;  
+  const refY = window.scrollY + getNavOffsetPx() + 10;  
+  let current = sections[0]?.id || "drop";  
+  for (const sec of sections) if (sec && sec.offsetTop <= refY) current = sec.id;  
+  setActive(current);  
+};  
+
+const onScroll = () => {  
+  if (raf || activeRoute) return;  
+  raf = requestAnimationFrame(() => {  
+    raf = null;  
+    updateActiveFromScroll();  
+  });  
+};
+
+function parseRoute() {
+  const params = new URLSearchParams(window.location.search);
+  return {
+    page: params.get("page"),
+    lookbookIndex: params.get("i"),
+    productId: params.get("id"),
+    hashId: (location.hash || "").replace("#", "")
+  };
+}
 
 function renderLookbookRoute(i) {  
-  const idx = Math.max(1, parseInt(i || "1", 10));  
   const items = catalog.lookbook || [];  
   const total = items.length || 1;  
+  const idx = Math.max(1, parseInt(i || "1", 10));  
   const safeIdx = Math.min(idx, total);  
   const item = items[safeIdx - 1] || items[0];  
-  if (rlbImg) rlbImg.src = item?.image || "";  
+  activeLookbookIndex = safeIdx;
+  if (rlbImg) {
+    rlbImg.src = item?.image || "";
+    rlbImg.alt = item?.alt || `Lookbook image ${safeIdx}`;
+  }
+  if (rlbMeta) rlbMeta.textContent = `Look ${safeIdx} of ${total}`;
+  if (rlbPrev) rlbPrev.disabled = total <= 1;
+  if (rlbNext) rlbNext.disabled = total <= 1;
 }  
 
 function updateRppAddState() {  
@@ -1119,84 +1169,79 @@ async function renderProductRoute(id) {
   if (rpp.add) rpp.add.disabled = true;  
 
   setRppImage(0);  
-}  
+}
 
-if (page === "lookbook") {  
-  showRoute("lookbook");  
-  renderLookbookRoute(params.get("i"));  
-} else if (page === "product") {  
-  showRoute("product");  
-  await renderProductRoute(params.get("id"));  
-} else {  
-  showRoute(null);  
+async function applyRoute() {
+  const { page, lookbookIndex, productId, hashId } = parseRoute();
+  activeRoute = page || null;
 
-  const sectionIds = ["drop", "lookbook", "shop", "about"];  
-  const sections = sectionIds.map((id) => document.getElementById(id)).filter(Boolean);  
+  if (page === "lookbook") {
+    showRoute("lookbook");
+    renderLookbookRoute(lookbookIndex);
+    document.title = `FAIDE | Lookbook ${activeLookbookIndex}`;
+    return;
+  }
 
-  function setActive(id) {  
-    navLinks.forEach((a) => {  
-      a.classList.remove("active");  
-      a.removeAttribute("aria-current");  
-    });  
-    Array.from(navLinks)  
-      .filter((a) => (a.getAttribute("href") || "").endsWith(`#${id}`))  
-      .forEach((lnk) => {  
-        lnk.classList.add("active");  
-        lnk.setAttribute("aria-current", "page");  
-      });  
-  }  
+  if (page === "product") {
+    showRoute("product");
+    await renderProductRoute(productId);
+    document.title = rppProduct ? `FAIDE | ${rppProduct.name}` : "FAIDE | Product";
+    return;
+  }
 
-  let navLock = false;  
-  let navUnlockTimer = null;  
+  showRoute(null);
+  document.title = "FAIDE | Luxury Streetwear Brand";
+  updateActiveFromScroll();
 
-  navLinks.forEach((a) => {  
-    a.addEventListener("click", (e) => {  
-      const href = a.getAttribute("href") || "";  
-      if (!href.includes("#")) return;  
-      const id = href.split("#")[1];  
-      if (!id) return;  
+  if (hashId && ["drop", "lookbook", "shop", "about", "footer"].includes(hashId)) {
+    setTimeout(() => {
+      scrollToSectionId(hashId);
+      setActive(hashId === "footer" ? "about" : hashId);
+    }, 30);
+  }
+}
 
-      e.preventDefault();  
-      navLock = true;  
-      clearTimeout(navUnlockTimer);  
+navLinks.forEach((a) => {
+  a.addEventListener("click", (e) => {
+    const href = a.getAttribute("href") || "";
+    if (!href.includes("#")) return;
+    const id = href.split("#")[1];
+    if (!id) return;
 
-      setActive(id);  
-      scrollToSectionId(id);  
+    e.preventDefault();
+    navLock = true;
+    clearTimeout(navUnlockTimer);
+    setActive(id);
 
-      navUnlockTimer = setTimeout(() => (navLock = false), 650);  
-      history.replaceState(null, "", `${location.pathname}#${id}`);  
-    });  
-  });  
+    if (activeRoute) {
+      gotoHomeSection(id);
+    } else {
+      scrollToSectionId(id);
+      history.replaceState({}, "", `${location.pathname}#${id}`);
+    }
 
-  let raf = null;  
-  const updateActiveFromScroll = () => {  
-    if (navLock) return;  
-    const refY = window.scrollY + getNavOffsetPx() + 10;  
-    let current = sections[0]?.id || "drop";  
-    for (const sec of sections) if (sec && sec.offsetTop <= refY) current = sec.id;  
-    setActive(current);  
-  };  
+    navUnlockTimer = setTimeout(() => (navLock = false), 650);
+  });
+});
 
-  const onScroll = () => {  
-    if (raf) return;  
-    raf = requestAnimationFrame(() => {  
-      raf = null;  
-      updateActiveFromScroll();  
-    });  
-  };  
+rlbPrev?.addEventListener("click", () => {
+  const total = (catalog.lookbook || []).length || 1;
+  const next = activeLookbookIndex <= 1 ? total : activeLookbookIndex - 1;
+  gotoLookbook(next);
+});
+rlbNext?.addEventListener("click", () => {
+  const total = (catalog.lookbook || []).length || 1;
+  const next = activeLookbookIndex >= total ? 1 : activeLookbookIndex + 1;
+  gotoLookbook(next);
+});
 
-  updateActiveFromScroll();  
-  window.addEventListener("scroll", onScroll, { passive: true });  
-  window.addEventListener("resize", updateActiveFromScroll, { passive: true });  
+window.addEventListener("scroll", onScroll, { passive: true });
+window.addEventListener("resize", updateActiveFromScroll, { passive: true });
+window.addEventListener("faide:navigate", () => {
+  applyRoute();
+});
 
-  const hashId = (location.hash || "").replace("#", "");  
-  if (hashId && ["drop", "lookbook", "shop", "about", "footer"].includes(hashId)) {  
-    setTimeout(() => {  
-      scrollToSectionId(hashId);  
-      setActive(hashId === "footer" ? "about" : hashId);  
-    }, 30);  
-  }  
-}  
+await applyRoute();
 
 // Product route add to cart  
 rpp.add?.addEventListener("click", () => {  
@@ -1269,6 +1314,7 @@ window.addEventListener("popstate", () => {
   if ($("policy-modal")?.style.display === "block") return policies.close();  
   if ($("cart-sidebar")?.classList.contains("active")) return closeCartPanel();  
   if (drawer?.classList.contains("open")) return closeDrawer();  
+  applyRoute();
 });  
 
 // ESC handling  

--- a/public/assets/js/products.json
+++ b/public/assets/js/products.json
@@ -1,7 +1,15 @@
 {
   "lookbook": [
-    { "id": 1, "image": "images/lookbook1.png", "alt": "FAIDE Lookbook 1" },
-    { "id": 2, "image": "images/lookbook2.png", "alt": "FAIDE Lookbook 2" }
+    {
+      "id": 1,
+      "image": "images/lookbook1.png",
+      "alt": "FAIDE Lookbook 1"
+    },
+    {
+      "id": 2,
+      "image": "images/lookbook2.png",
+      "alt": "FAIDE Lookbook 2"
+    }
   ],
   "products": [
     {
@@ -11,12 +19,28 @@
       "category": "UNISEX Tank Top",
       "price": 199.99,
       "currencySymbol": "R",
-      "sizes": ["S", "M", "L", "XL"],
-      "colors": [
-        { "name": "Black", "className": "color black" },
-        { "name": "White", "className": "color white" }
+      "sizes": [
+        "S",
+        "M",
+        "L",
+        "XL"
       ],
-      "images": ["images/tank-top.png", "images/tank-top1.png", "images/tank-top2.png", "images/tank-top3.png"]
+      "colors": [
+        {
+          "name": "Black",
+          "className": "color black"
+        },
+        {
+          "name": "White",
+          "className": "color white"
+        }
+      ],
+      "images": [
+        "images/tank-top.png",
+        "images/tank-top1.png",
+        "images/tank-top2.png",
+        "images/tank-top3.png"
+      ]
     },
     {
       "id": "tee",
@@ -25,13 +49,32 @@
       "category": "UNISEX Short-Sleeve Top",
       "price": 349.99,
       "currencySymbol": "R",
-      "sizes": ["S", "M", "L", "XL"],
-      "colors": [
-        { "name": "Black", "className": "color black" },
-        { "name": "White", "className": "color white" },
-        { "name": "Grey", "className": "color grey" }
+      "sizes": [
+        "S",
+        "M",
+        "L",
+        "XL"
       ],
-      "images": ["images/tshirt.png", "images/tshirt1.png", "images/tshirt2.png", "images/tshirt3.png"]
+      "colors": [
+        {
+          "name": "Black",
+          "className": "color black"
+        },
+        {
+          "name": "White",
+          "className": "color white"
+        },
+        {
+          "name": "Grey",
+          "className": "color grey"
+        }
+      ],
+      "images": [
+        "images/tshirt.png",
+        "images/tshirt1.png",
+        "images/tshirt2.png",
+        "images/tshirt3.png"
+      ]
     },
     {
       "id": "longsleeve",
@@ -40,12 +83,28 @@
       "category": "UNISEX Long Sleeve",
       "price": 549.99,
       "currencySymbol": "R",
-      "sizes": ["S", "M", "L", "XL"],
-      "colors": [
-        { "name": "Black", "className": "color black" },
-        { "name": "White", "className": "color white" }
+      "sizes": [
+        "S",
+        "M",
+        "L",
+        "XL"
       ],
-      "images": ["images/longsleeve.png", "images/longsleeve1.png", "images/longsleeve2.png", "images/longsleeve3.png"]
+      "colors": [
+        {
+          "name": "Black",
+          "className": "color black"
+        },
+        {
+          "name": "White",
+          "className": "color white"
+        }
+      ],
+      "images": [
+        "images/longsleeve.png",
+        "images/longsleeve1.png",
+        "images/longsleeve2.png",
+        "images/longsleeve3.png"
+      ]
     },
     {
       "id": "hoodie",
@@ -54,12 +113,28 @@
       "category": "UNISEX Pullover Hoodie",
       "price": 699.99,
       "currencySymbol": "R",
-      "sizes": ["S", "M", "L", "XL"],
-      "colors": [
-        { "name": "Black", "className": "color black" },
-        { "name": "White", "className": "color white" }
+      "sizes": [
+        "S",
+        "M",
+        "L",
+        "XL"
       ],
-      "images": ["images/hoodie.png", "images/hoodie1.png", "images/hoodie2.png", "images/hoodie3.png"]
+      "colors": [
+        {
+          "name": "Black",
+          "className": "color black"
+        },
+        {
+          "name": "White",
+          "className": "color white"
+        }
+      ],
+      "images": [
+        "images/hoodie.png",
+        "images/hoodie1.png",
+        "images/hoodie2.png",
+        "images/hoodie3.png"
+      ]
     },
     {
       "id": "beanie",
@@ -68,15 +143,22 @@
       "category": "UNISEX Beanie",
       "price": 119.99,
       "currencySymbol": "R",
-
-      "sizes": ["One Size"],
-
-      "colors": [
-        { "name": "Black", "className": "color black" },
-        { "name": "White", "className": "color white" }
+      "sizes": [
+        "One Size"
       ],
-
-      "images": ["images/beanie.jpg", "images/beanie1.png", "images/beanie2.png", "images/beanie3.png"]
+      "colors": [
+        {
+          "name": "Black",
+          "className": "color black"
+        },
+        {
+          "name": "White",
+          "className": "color white"
+        }
+      ],
+      "images": [
+        "images/beanie.jpg"
+      ]
     }
   ]
 }

--- a/public/index.html
+++ b/public/index.html
@@ -15,7 +15,7 @@
     <meta name="theme-color" content="#000000" />  
   
     <link rel="icon" href="favicon.png" />  
-    <link rel="apple-touch-icon" href="apple-touch-icon.png" />  
+    <link rel="apple-touch-icon" href="favicon.png" />  
   
     <link rel="preload" as="image" href="images/hero.png" />  
     <link rel="preload" as="image" href="images/faide-wordmark.png" />  
@@ -164,8 +164,11 @@
         </div>  
   
         <div class="lookbook-view">  
+          <button type="button" class="route-arrow route-arrow-left" id="rlb-prev" aria-label="Previous lookbook image">‹</button>
           <img id="rlb-img" alt="Lookbook image" src="" />  
-        </div>  
+          <button type="button" class="route-arrow route-arrow-right" id="rlb-next" aria-label="Next lookbook image">›</button>
+        </div>
+        <div class="route-meta" id="rlb-meta"></div>  
       </div>  
     </main>  
   
@@ -225,7 +228,7 @@
   
             <button type="button" class="secondary-btn" id="rpp-add" disabled>Add to Bag</button>  
   
-            <div class="rpp-hint">Tap thumbnails • Select size &amp; color • Add to Bag</div>  
+            <div class="rpp-hint">Choose a size and color, then add it to your bag.</div>  
           </div>  
         </section>  
       </div>  
@@ -454,7 +457,7 @@
           <div class="checkout-banner">  
             <div class="checkout-banner-title">Card Payments: Coming Soon</div>  
             <div class="checkout-banner-text">  
-              We’re finishing secure card checkout. For now, you can view your cart here and we’ll enable payments soon.  
+              Card checkout is not live yet. Save your details for faster checkout later.  
             </div>  
           </div>  
   
@@ -483,7 +486,7 @@
             </button>  
   
             <div class="checkout-note">  
-              This does not place an order yet. It only saves your details locally on this device for faster checkout later.  
+              This only saves your details on this device.  
             </div>  
           </div>  
   
@@ -526,7 +529,7 @@
           <div class="signup-form">  
             <input id="su-email" type="email" placeholder="Email address" autocomplete="email" />  
             <button id="su-submit" type="button" class="secondary-btn">Sign Up</button>  
-            <div class="signup-note">We won’t spam you. You can unsubscribe anytime.</div>  
+            <div class="signup-note">Drop alerts only.</div>  
           </div>  
         </div>  
       </div>  


### PR DESCRIPTION
### Motivation
- Remove syntax bugs and stray copy that prevented the storefront from running correctly and caused confusing UX. 
- Improve client-side routing so lookbook/product routes are navigable without full page reloads and back/forward behave predictably. 
- Ensure the app only references existing assets and presents a simpler, clearer checkout/signup experience.

### Description
- Fixed JavaScript template literal and rendering bugs and restored valid helpers such as `formatPriceZAR`, `renderLookbook`, and card rendering in `public/assets/js/app.js`. 
- Reworked routing to use the History API via `navigateTo`, `gotoLookbook`, `gotoProduct`, `gotoHomeSection`, an `faide:navigate` event and an `applyRoute` flow so routes update page title and UI without full reloads. 
- Added lookbook controls (`rlb-prev`, `rlb-next`) plus a `rlb-meta` label and corresponding CSS (`.route-arrow`, lookbook grid layout) to `public/index.html` and `public/assets/css/style.css` for desktop/mobile navigation. 
- Cleaned copy in the product/checkout/signup modals and fixed `apple-touch-icon` to use an existing asset, and trimmed `public/assets/js/products.json` to remove references to non-existent beanie gallery images.

### Testing
- Ran `node --check public/assets/js/app.js` to validate JavaScript syntax which succeeded. 
- Validated JSON with `python -m json.tool public/assets/js/products.json` which succeeded. 
- Served the `public` folder with `python -m http.server` and exercised endpoints with `curl -I /`, `curl -I '/?page=lookbook&i=2'`, and `curl -I '/?page=product&id=beanie'`, all of which returned HTTP 200 responses.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bda6f270e08325b3035882e04c4bae)