### PR TITLE
FAIDE OFFICIAL

### DIFF
--- a/public/assets/css/style.css
+++ b/public/assets/css/style.css
@@ -230,6 +230,9 @@ body.nav-hidden #navbar {
   border:1px solid rgba(255,255,255,0.08);
 }
 .drawer-links a:hover { border-color: rgba(168,85,247,0.35); color:#fff; }
+.drawer-footer { margin-top:auto; padding:18px; border-top:1px solid rgba(255,255,255,0.08); display:grid; gap:10px; }
+.drawer-login-btn { width:100%; border:none; border-radius:999px; padding:14px 18px; background: linear-gradient(135deg, var(--secondary) 0%, var(--primary) 100%); color:#fff; font-weight:900; letter-spacing:0.08em; text-transform:uppercase; cursor:pointer; }
+.drawer-note { color:#8f8f8f; font-size:0.85rem; line-height:1.5; }
 
 /* Sections */
 .hero, .lookbook, .shop, .about { padding-top: var(--section-y); padding-bottom: var(--section-y); }
@@ -411,10 +414,13 @@ body.nav-hidden #navbar {
   margin-top:18px;
   width:100%;
   background:#000;
-  display:flex;
+  display:grid;
+  grid-template-columns: auto minmax(0, 1fr) auto;
   align-items:center;
   justify-content:center;
+  gap:14px;
   border:1px solid rgba(255,255,255,0.08);
+  padding:14px;
 }
 .lookbook-view img {
   width:100%;
@@ -423,6 +429,42 @@ body.nav-hidden #navbar {
   display:block;
   user-select:none;
   -webkit-user-drag:none;
+}
+
+
+.route-arrow {
+  width: 48px;
+  height: 48px;
+  border-radius: 999px;
+  border: 1px solid rgba(255,255,255,0.14);
+  background: rgba(255,255,255,0.04);
+  color: #fff;
+  font-size: 2rem;
+  line-height: 1;
+  cursor: pointer;
+}
+.route-arrow:disabled {
+  opacity: 0.35;
+  cursor: default;
+}
+.route-meta {
+  margin-top: 12px;
+  color: var(--muted);
+  text-align: center;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  font-size: 0.75rem;
+}
+@media (max-width:768px) {
+  .lookbook-view {
+    grid-template-columns: 1fr;
+  }
+  .route-arrow {
+    width: 100%;
+    height: 42px;
+    font-size: 1.5rem;
+  }
 }
 
 /* Product route */
@@ -922,6 +964,7 @@ body.nav-hidden #navbar {
   border-bottom:1px solid var(--border);
   background: var(--surface);
 }
+.cart-kicker { color: var(--muted); text-transform: uppercase; letter-spacing: 0.14em; font-size: 0.72rem; font-weight: 900; margin-bottom: 6px; }
 .cart-header h2 { font-size:1.5rem; font-weight:700; color: var(--primary); margin:0; }
 .close-cart {
   background:transparent;
@@ -937,7 +980,11 @@ body.nav-hidden #navbar {
 }
 .close-cart:hover { color:#fff; background:#1a1a1a; transform: translateY(-1px); }
 .close-cart:active { transform: translateY(-2px); }
-.cart-items { flex:1; overflow-y:auto; padding:24px; list-style:none; }
+.cart-body { flex:1; overflow-y:auto; padding:20px 24px 0; }
+.cart-summary-card { display:grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap:14px; padding:16px; border-radius:18px; background: linear-gradient(180deg, rgba(168,85,247,0.12), rgba(255,255,255,0.03)); border:1px solid rgba(168,85,247,0.18); margin-bottom:18px; }
+.cart-summary-label { color:#a1a1aa; font-size:0.8rem; text-transform:uppercase; letter-spacing:0.08em; font-weight:800; }
+.cart-summary-value { color:#fff; font-size:1rem; font-weight:900; margin-top:4px; }
+.cart-items { overflow-y:auto; padding:0; list-style:none; }
 .cart-item {
   background: var(--surface);
   padding:14px;
@@ -962,8 +1009,9 @@ body.nav-hidden #navbar {
 .cart-footer {
   padding:24px;
   border-top:1px solid var(--border);
-  background: var(--surface);
+  background: linear-gradient(180deg, rgba(17,17,17,0.98), rgba(10,10,10,1));
 }
+.cart-meta { display:flex; justify-content:space-between; gap:12px; color:#8b8b8b; font-size:0.8rem; margin-bottom:16px; }
 .cart-total-row { display:flex; justify-content:space-between; align-items:center; margin-bottom:20px; font-size:1.3rem; }
 .cart-total-label { font-weight:700; color:#888; }
 .cart-total-value { font-weight:700; color: var(--primary); font-size:1.5rem; }
@@ -1005,6 +1053,9 @@ body.nav-hidden #navbar {
   .cart-sidebar { width:100%; right:-100%; }
   .floating-cart { bottom:24px; right:24px; width:56px; height:56px; }
   .cart-toast { bottom:100px; right:24px; left:24px; max-width: calc(100% - 48px); }
+  .cart-body { padding:16px 16px 0; }
+  .cart-summary-card { grid-template-columns: 1fr; }
+  .cart-meta { flex-direction:column; }
   .cart-item {
     grid-template-columns: 58px 1fr;
     grid-template-areas:
@@ -1032,6 +1083,7 @@ body.nav-hidden #navbar {
   border: 1px solid var(--border);
   overflow: hidden;
 }
+.modal-card-narrow { max-width: 520px; }
 .modal-head {
   background: var(--surface);
   padding: 24px;
@@ -1082,7 +1134,8 @@ body.nav-hidden #navbar {
     display: flex;
     flex-direction: column;
   }
-  .modal-head {
+  .modal-card-narrow { max-width: 520px; }
+.modal-head {
     padding: 18px 16px;
     flex: 0 0 auto;
   }
@@ -1105,6 +1158,7 @@ body.nav-hidden #navbar {
 .checkout-banner-title, .signup-title { font-weight:950; color:#fff; letter-spacing:0.02em; }
 .checkout-banner-text, .signup-text { color:#bdbdbd; margin-top:6px; line-height:1.5; }
 
+.checkout-layout { display:grid; grid-template-columns: 0.9fr 1.1fr; gap:18px; align-items:start; }
 .checkout-summary {
   border:1px solid rgba(255,255,255,0.08);
   background: rgba(255,255,255,0.03);
@@ -1112,11 +1166,14 @@ body.nav-hidden #navbar {
   padding:14px 16px;
   margin-bottom:18px;
 }
-.checkout-summary-row { display:flex; align-items:center; justify-content:space-between; gap:12px; padding:8px 0; }
+.checkout-summary-row { display:flex; align-items:center; justify-content:space-between; gap:12px; padding:10px 0; }
+.checkout-summary-primary { height:100%; }
+.checkout-summary-total { border-top:1px solid rgba(255,255,255,0.08); margin-top:8px; padding-top:14px; }
 .checkout-muted { color:#9a9a9a; font-weight:800; }
 .checkout-strong { color:#fff; font-weight:950; }
 
-.checkout-form-title { font-weight:950; color:#fff; margin:12px 0 12px; }
+.checkout-form { border:1px solid rgba(255,255,255,0.08); background: rgba(255,255,255,0.02); border-radius:18px; padding:18px; }
+.checkout-form-title { font-weight:950; color:#fff; margin:0 0 12px; }
 
 .checkout-grid {
   display:grid;
@@ -1136,6 +1193,8 @@ body.nav-hidden #navbar {
 .checkout-grid input::placeholder, .signup-form input::placeholder { color:#777; font-weight:800; }
 .checkout-grid input:focus, .signup-form input:focus { border-color: rgba(168,85,247,0.7); background: rgba(255,255,255,0.045); }
 
+@media (max-width:900px) { .checkout-layout { grid-template-columns: 1fr; } }
+.checkout-grid-single { margin-top:12px; }
 @media (max-width:700px) { .checkout-grid { grid-template-columns: 1fr; } }
 
 .checkout-note { color:#888; font-size:0.9rem; margin-top:10px; line-height:1.5; }
@@ -1168,4 +1227,5 @@ body.nav-hidden #navbar {
 }
 
 .signup-form { display:grid; gap:12px; }
+.signup-later-btn { width:100%; }
 .signup-note { color:#888; font-size:0.9rem; line-height:1.5; }

--- a/public/assets/js/app.js
+++ b/public/assets/js/app.js
@@ -135,12 +135,26 @@ const qs = url.searchParams.toString();
 return qs ? url.pathname + "?" + qs : url.pathname;
 }
 
-function gotoLookbook(i) {
-window.location.href = toQueryUrl({ page: "lookbook", i });
+function navigateTo(params, { replace = false } = {}) {
+const target = toQueryUrl(params);
+if (replace) history.replaceState(params, "", target);
+else history.pushState(params, "", target);
+window.dispatchEvent(new CustomEvent("faide:navigate"));
 }
 
-function gotoProduct(id) {
-window.location.href = toQueryUrl({ page: "product", id });
+function gotoLookbook(i, options) {
+navigateTo({ page: "lookbook", i }, options);
+}
+
+function gotoProduct(id, options) {
+navigateTo({ page: "product", id }, options);
+}
+
+function gotoHomeSection(id = "drop", { replace = false } = {}) {
+const target = `${window.location.pathname}#${id}`;
+if (replace) history.replaceState({}, "", target);
+else history.pushState({}, "", target);
+window.dispatchEvent(new CustomEvent("faide:navigate"));
 }
 
 function showRoute(page) {
@@ -319,16 +333,30 @@ function setNavHidden(hidden) {
 document.body.classList.toggle("nav-hidden", !!hidden);
 }
 
-// Back gesture handling: when a modal/cart opens on mobile, push a history state.
+// Back gesture handling: keep overlay states in sync with browser history on mobile.
 let modalDepth = 0;
-function pushModalState() {
+let ignoreNextPop = false;
+
+function pushModalState(layer) {
 if (!isMobile()) return;
 modalDepth += 1;
-history.pushState({ __faideModal: true, depth: modalDepth }, "");
+history.pushState({ __faideModal: true, layer, depth: modalDepth }, "");
 }
-function popModalState() {
+
+function requestHistoryBack(closeFallback) {
+if (!isMobile() || !history.state?.__faideModal) return false;
+ignoreNextPop = true;
+history.back();
+setTimeout(() => {
+  ignoreNextPop = false;
+  closeFallback?.();
+}, 160);
+return true;
+}
+
+function consumeModalDepth() {
 if (!isMobile()) return;
-if (modalDepth > 0) modalDepth -= 1;
+modalDepth = Math.max(0, modalDepth - 1);
 }
 
 // ---------- Policies ----------
@@ -455,23 +483,40 @@ localStorage.setItem(CHECKOUT_PROFILE_KEY, JSON.stringify(profile || {}));
 } catch {}
 }
 
+const LOGIN_STORAGE_KEY = "faide_login_v1";
+function saveLoginSession(session) {
+try {
+localStorage.setItem(LOGIN_STORAGE_KEY, JSON.stringify(session || {}));
+} catch {}
+}
+function isValidEmail(email) {
+return /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(String(email || "").trim());
+}
+
 function initCheckoutModal(getCartTotals, openModal, closeModal) {
 const overlay = $("checkout-modal");
 const close1 = $("checkout-close");
 const close2 = $("checkout-close-2");
 const itemsCount = $("checkout-items-count");
 const totalEl = $("checkout-total");
+const totalEstimateEl = $("checkout-total-estimate");
 const submit = $("co-submit");
 
 const nameEl = $("co-name");  
 const emailEl = $("co-email");  
 const phoneEl = $("co-phone");  
 const cityEl = $("co-city");  
+const addressEl = $("co-address");
+
+function syncTotals() {
+  const { itemCount, total } = getCartTotals();
+  if (itemsCount) itemsCount.textContent = String(itemCount);
+  if (totalEl) totalEl.textContent = total.toFixed(2);
+  if (totalEstimateEl) totalEstimateEl.textContent = total.toFixed(2);
+}
 
 function open() {  
-  const { itemCount, total } = getCartTotals();  
-  if (itemsCount) itemsCount.textContent = String(itemCount);  
-  if (totalEl) totalEl.textContent = total.toFixed(2);  
+  syncTotals();
 
   const profile = loadCheckoutProfile();  
   if (profile) {  
@@ -479,17 +524,19 @@ function open() {
     if (emailEl) emailEl.value = profile.email || "";  
     if (phoneEl) phoneEl.value = profile.phone || "";  
     if (cityEl) cityEl.value = profile.city || "";  
+    if (addressEl) addressEl.value = profile.address || "";
   }  
 
-  openModal(overlay, emailEl);  
+  openModal(overlay, emailEl, "checkout");  
 }  
 
-function close() {  
+function close(fromPop = false) {  
+  if (!fromPop && requestHistoryBack(() => close(true))) return;
   closeModal(overlay);  
 }  
 
-close1?.addEventListener("click", close);  
-close2?.addEventListener("click", close);  
+close1?.addEventListener("click", () => close());  
+close2?.addEventListener("click", () => close());  
 overlay?.addEventListener("click", (e) => {  
   if (e.target === overlay) close();  
 });  
@@ -499,16 +546,19 @@ submit?.addEventListener("click", () => {
     name: nameEl?.value?.trim() || "",  
     email: emailEl?.value?.trim() || "",  
     phone: phoneEl?.value?.trim() || "",  
-    city: cityEl?.value?.trim() || ""  
+    city: cityEl?.value?.trim() || "",
+    address: addressEl?.value?.trim() || ""
   };  
 
-  if (!profile.email) return showCartToast("Please enter an email.");  
+  if (!profile.name) return showCartToast("Please enter your name.");
+  if (!isValidEmail(profile.email)) return showCartToast("Please enter a valid email.");
+  if (!profile.phone) return showCartToast("Please enter a phone number.");
   saveCheckoutProfile(profile);  
-  showCartToast("Saved. We’ll notify you when payments go live.");  
+  showCartToast("Details saved for faster checkout.");  
   close();  
 });  
 
-return { open, close, isOpen: () => overlay?.style.display === "block" };
+return { open, close, syncTotals, isOpen: () => overlay?.style.display === "block" };
 
 }
 
@@ -517,31 +567,38 @@ const SIGNUP_KEY = "faide_signup_v1";
 function initSignupModal(openModal, closeModal) {
 const overlay = $("signup-modal");
 const closeBtn = $("signup-close");
+const laterBtn = $("su-later");
+const nameEl = $("su-name");
 const emailEl = $("su-email");
 const submit = $("su-submit");
 
 function open() {  
-  openModal(overlay, emailEl);  
+  openModal(overlay, emailEl, "signup");  
 }  
-function close() {  
+function close(fromPop = false) {  
+  if (!fromPop && requestHistoryBack(() => close(true))) return;
   closeModal(overlay);  
 }  
 
-closeBtn?.addEventListener("click", close);  
+closeBtn?.addEventListener("click", () => close());  
+laterBtn?.addEventListener("click", () => close());
+
 overlay?.addEventListener("click", (e) => {  
   if (e.target === overlay) close();  
 });  
 
 submit?.addEventListener("click", () => {  
+  const name = nameEl?.value?.trim() || "";
   const email = emailEl?.value?.trim() || "";  
-  if (!email || !email.includes("@") || !email.includes(".")) {  
+  if (!name) return showCartToast("Add your first name.");
+  if (!isValidEmail(email)) {  
     showCartToast("Please enter a valid email.");  
     return;  
   }  
   try {  
-    localStorage.setItem(SIGNUP_KEY, JSON.stringify({ email, ts: Date.now() }));  
+    localStorage.setItem(SIGNUP_KEY, JSON.stringify({ name, email, ts: Date.now() }));  
   } catch {}  
-  showCartToast("You’re in. Drop alerts enabled.");  
+  showCartToast(`Thanks ${name}. Drop alerts enabled.`);  
   close();  
 });  
 
@@ -549,9 +606,44 @@ return { open, close, isOpen: () => overlay?.style.display === "block" };
 
 }
 
+function initLoginModal(openModal, closeModal, closeDrawer) {
+const overlay = $("login-modal");
+const closeBtn = $("login-close");
+const openBtn = $("drawer-login-btn");
+const emailEl = $("login-email");
+const passwordEl = $("login-password");
+const submitBtn = $("login-submit");
+
+function open() {
+  closeDrawer?.();
+  openModal(overlay, emailEl, "login");
+}
+function close(fromPop = false) {
+  if (!fromPop && requestHistoryBack(() => close(true))) return;
+  closeModal(overlay);
+}
+
+openBtn?.addEventListener("click", open);
+closeBtn?.addEventListener("click", () => close());
+overlay?.addEventListener("click", (e) => {
+  if (e.target === overlay) close();
+});
+submitBtn?.addEventListener("click", () => {
+  const email = emailEl?.value?.trim() || "";
+  const password = passwordEl?.value || "";
+  if (!isValidEmail(email)) return showCartToast("Enter a valid login email.");
+  if (password.length < 6) return showCartToast("Password must be at least 6 characters.");
+  saveLoginSession({ email, ts: Date.now() });
+  showCartToast("Login saved on this device.");
+  close();
+});
+
+return { open, close, isOpen: () => overlay?.style.display === "block" };
+}
+
 function formatPriceZAR(price) {
 const n = Number(price || 0);
-return R${n.toFixed(2)};
+return `R${n.toFixed(2)}`;
 }
 
 function renderLookbook(listEl, lookbookItems) {
@@ -562,8 +654,8 @@ const card = document.createElement("div");
 card.className = "lookbook-card";
 card.setAttribute("role", "button");
 card.setAttribute("tabindex", "0");
-card.setAttribute("aria-label", Open Lookbook ${item.id});
-card.innerHTML = <img src="${item.image}" alt="${item.alt || "Lookbook"}" class="lookbook-img" />;
+card.setAttribute("aria-label", `Open lookbook image ${item.id}`);
+card.innerHTML = `<img src="${item.image}" alt="${item.alt || "Lookbook"}" class="lookbook-img" />`;
 const go = () => gotoLookbook(String(item.id));
 card.addEventListener("click", go);
 clickOnEnterSpace(card, go);
@@ -667,12 +759,28 @@ handleShrink();
 window.addEventListener("scroll", handleShrink, { passive: true });  
 
 // ---------- Modal open/close (shared) ----------  
-function openModal(modalEl, focusEl) {  
-  if (!modalEl) return;  
+function anyLayerOpen() {
+  return (
+    $("policy-modal")?.style.display === "block" ||
+    $("checkout-modal")?.style.display === "block" ||
+    $("signup-modal")?.style.display === "block" ||
+    $("login-modal")?.style.display === "block" ||
+    $("cart-sidebar")?.classList.contains("active") ||
+    drawer?.classList.contains("open")
+  );
+}
+
+function syncLockState() {
+  const locked = anyLayerOpen();
+  document.body.classList.toggle("lock-scroll", locked);
+  setNavHidden(locked);
+}
+
+function openModal(modalEl, focusEl, layer = "modal") {  
+  if (!modalEl || modalEl.style.display === "block") return;  
   modalEl.style.display = "block";  
-  document.body.classList.add("lock-scroll");  
-  setNavHidden(true);  
-  pushModalState();  
+  syncLockState();
+  pushModalState(layer);  
   setTimeout(() => focusEl?.focus?.(), 50);  
 }  
 
@@ -680,42 +788,37 @@ function closeModal(modalEl) {
   if (!modalEl) return;  
   if (modalEl.style.display !== "block") return;  
   modalEl.style.display = "none";  
-  document.body.classList.remove("lock-scroll");  
-
-  const anyOpen =  
-    $("policy-modal")?.style.display === "block" ||  
-    $("checkout-modal")?.style.display === "block" ||  
-    $("signup-modal")?.style.display === "block" ||  
-    $("cart-sidebar")?.classList.contains("active");  
-
-  setNavHidden(anyOpen);  
-  popModalState();  
+  consumeModalDepth();
+  syncLockState();  
 }  
 
 // Drawer open/close  
 function openDrawer() {  
-  if (!drawer || !drawerOverlay) return;  
+  if (!drawer || !drawerOverlay || drawer.classList.contains("open")) return;  
   drawer.classList.add("open");  
   drawer.setAttribute("aria-hidden", "false");  
   drawerOverlay.classList.add("active");  
   menuBtn?.setAttribute("aria-expanded", "true");  
-  document.body.classList.add("lock-scroll");  
+  syncLockState();
+  pushModalState("drawer");
 }  
-function closeDrawer() {  
+function closeDrawer(fromPop = false) {  
   if (!drawer || !drawerOverlay) return;  
+  if (!fromPop && requestHistoryBack(() => closeDrawer(true))) return;
   drawer.classList.remove("open");  
   drawer.setAttribute("aria-hidden", "true");  
   drawerOverlay.classList.remove("active");  
   menuBtn?.setAttribute("aria-expanded", "false");  
-  document.body.classList.remove("lock-scroll");  
+  consumeModalDepth();
+  syncLockState();  
 }  
 
 menuBtn?.addEventListener("click", () => {  
   if (drawer?.classList.contains("open")) closeDrawer();  
   else openDrawer();  
 });  
-drawerClose?.addEventListener("click", closeDrawer);  
-drawerOverlay?.addEventListener("click", closeDrawer);  
+drawerClose?.addEventListener("click", () => closeDrawer());  
+drawerOverlay?.addEventListener("click", () => closeDrawer());  
 
 navLinks.forEach((a) => a.addEventListener("click", () => closeDrawer()));  
 
@@ -758,29 +861,31 @@ const cartOverlay = $("cart-overlay");
 const closeCart = $("close-cart");  
 const cartItemsEl = $("cart-items");  
 const cartTotalEl = $("cart-total");  
+const cartSummaryTotalEl = $("cart-summary-total");
+const cartSummaryCountEl = $("cart-summary-count");
 const cartCountEl = $("cart-count");  
 const checkoutBtn = $("checkout-btn");  
 
 let cart = loadCartFromStorage();  
 
 function openCart() {  
+  if (cartSidebar?.classList.contains("active")) return;
   cartSidebar?.classList.add("active");  
   cartOverlay?.classList.add("active");  
-  document.body.classList.add("lock-scroll");  
-  setNavHidden(true);  
-  pushModalState();  
+  syncLockState();
+  pushModalState("cart");  
 }  
-function closeCartPanel() {  
+function closeCartPanel(fromPop = false) {  
+  if (!fromPop && requestHistoryBack(() => closeCartPanel(true))) return;
   cartSidebar?.classList.remove("active");  
   cartOverlay?.classList.remove("active");  
-  document.body.classList.remove("lock-scroll");  
-  setNavHidden(false);  
-  popModalState();  
+  consumeModalDepth();
+  syncLockState();  
 }  
 
 floatingCart?.addEventListener("click", openCart);  
-closeCart?.addEventListener("click", closeCartPanel);  
-cartOverlay?.addEventListener("click", closeCartPanel);  
+closeCart?.addEventListener("click", () => closeCartPanel());  
+cartOverlay?.addEventListener("click", () => closeCartPanel());  
 
 function setCheckoutState() {  
   const empty = cart.length === 0;  
@@ -800,6 +905,7 @@ function getCartTotals() {
 }  
 
 const checkoutModal = initCheckoutModal(getCartTotals, openModal, closeModal);  
+const loginModal = initLoginModal(openModal, closeModal, closeDrawer);  
 
 checkoutBtn?.addEventListener("click", (e) => {  
   e.preventDefault();  
@@ -813,12 +919,17 @@ function updateCartUI() {
 
   cartItemsEl.innerHTML = "";  
   const totals = getCartTotals();  
+  if (cartSummaryTotalEl) cartSummaryTotalEl.textContent = totals.total.toFixed(2);
+  if (cartSummaryCountEl) cartSummaryCountEl.textContent = `${totals.itemCount} ${totals.itemCount === 1 ? "piece" : "pieces"}`;
 
   if (cart.length === 0) {  
     cartItemsEl.innerHTML =  
-      '<li style="text-align:center;color:#666;border:none;background:transparent;padding:14px 0;">Your cart is empty</li>';  
+      '<li style="text-align:center;color:#666;border:none;background:transparent;padding:28px 0;">Your bag is empty. Add a product to get started.</li>';  
     cartTotalEl.textContent = "0.00";  
+    if (cartSummaryTotalEl) cartSummaryTotalEl.textContent = "0.00";
+    if (cartSummaryCountEl) cartSummaryCountEl.textContent = "0 pieces";
     cartCountEl.textContent = "0";  
+    checkoutModal.syncTotals?.();
     setCheckoutState();  
     return;  
   }  
@@ -864,7 +975,10 @@ function updateCartUI() {
   });  
 
   cartTotalEl.textContent = totals.total.toFixed(2);  
+  if (cartSummaryTotalEl) cartSummaryTotalEl.textContent = totals.total.toFixed(2);
+  if (cartSummaryCountEl) cartSummaryCountEl.textContent = `${totals.itemCount} ${totals.itemCount === 1 ? "piece" : "pieces"}`;
   cartCountEl.textContent = String(totals.itemCount);  
+  checkoutModal.syncTotals?.();
   setCheckoutState();  
 }  
 
@@ -964,27 +1078,10 @@ bindProductCards();
 updateCartUI();  
 
 // ---------- Routes ----------  
-const params = new URLSearchParams(window.location.search);  
-const page = params.get("page");  
-
-// nav click behavior  
-navLinks.forEach((a) => {  
-  a.addEventListener("click", (e) => {  
-    const href = a.getAttribute("href") || "";  
-    if (!href.includes("#")) return;  
-    if (page === "lookbook" || page === "product") {  
-      e.preventDefault();  
-      window.location.href = "index.html" + href;  
-    } else {  
-      e.preventDefault();  
-      const id = href.replace("#", "");  
-      scrollToSectionId(id);  
-      history.replaceState(null, "", `${location.pathname}#${id}`);  
-    }  
-  });  
-});  
-
 const rlbImg = $("rlb-img");  
+const rlbPrev = $("rlb-prev");
+const rlbNext = $("rlb-next");
+const rlbMeta = $("rlb-meta");
 
 const rpp = {  
   img: $("rpp-img"),  
@@ -1001,14 +1098,67 @@ const rpp = {
 
 const rppStepperRoot = document.querySelector('.qty-stepper-ui[data-qty-root="rpp"]');  
 const rppStepper = rppStepperRoot ? setupQtyStepper(rppStepperRoot) : null;  
+const sectionIds = ["drop", "lookbook", "shop", "about"];  
+const sections = sectionIds.map((id) => document.getElementById(id)).filter(Boolean);  
+let navLock = false;  
+let navUnlockTimer = null;  
+let raf = null;  
+let activeRoute = null;
+let activeLookbookIndex = 1;
+
+function setActive(id) {  
+  navLinks.forEach((a) => {  
+    a.classList.remove("active");  
+    a.removeAttribute("aria-current");  
+  });  
+  Array.from(navLinks)  
+    .filter((a) => (a.getAttribute("href") || "").endsWith(`#${id}`))  
+    .forEach((lnk) => {  
+      lnk.classList.add("active");  
+      lnk.setAttribute("aria-current", "page");  
+    });  
+}  
+
+const updateActiveFromScroll = () => {  
+  if (navLock || activeRoute) return;  
+  const refY = window.scrollY + getNavOffsetPx() + 10;  
+  let current = sections[0]?.id || "drop";  
+  for (const sec of sections) if (sec && sec.offsetTop <= refY) current = sec.id;  
+  setActive(current);  
+};  
+
+const onScroll = () => {  
+  if (raf || activeRoute) return;  
+  raf = requestAnimationFrame(() => {  
+    raf = null;  
+    updateActiveFromScroll();  
+  });  
+};
+
+function parseRoute() {
+  const params = new URLSearchParams(window.location.search);
+  return {
+    page: params.get("page"),
+    lookbookIndex: params.get("i"),
+    productId: params.get("id"),
+    hashId: (location.hash || "").replace("#", "")
+  };
+}
 
 function renderLookbookRoute(i) {  
-  const idx = Math.max(1, parseInt(i || "1", 10));  
   const items = catalog.lookbook || [];  
   const total = items.length || 1;  
+  const idx = Math.max(1, parseInt(i || "1", 10));  
   const safeIdx = Math.min(idx, total);  
   const item = items[safeIdx - 1] || items[0];  
-  if (rlbImg) rlbImg.src = item?.image || "";  
+  activeLookbookIndex = safeIdx;
+  if (rlbImg) {
+    rlbImg.src = item?.image || "";
+    rlbImg.alt = item?.alt || `Lookbook image ${safeIdx}`;
+  }
+  if (rlbMeta) rlbMeta.textContent = `Look ${safeIdx} of ${total}`;
+  if (rlbPrev) rlbPrev.disabled = total <= 1;
+  if (rlbNext) rlbNext.disabled = total <= 1;
 }  
 
 function updateRppAddState() {  
@@ -1119,84 +1269,79 @@ async function renderProductRoute(id) {
   if (rpp.add) rpp.add.disabled = true;  
 
   setRppImage(0);  
-}  
+}
 
-if (page === "lookbook") {  
-  showRoute("lookbook");  
-  renderLookbookRoute(params.get("i"));  
-} else if (page === "product") {  
-  showRoute("product");  
-  await renderProductRoute(params.get("id"));  
-} else {  
-  showRoute(null);  
+async function applyRoute() {
+  const { page, lookbookIndex, productId, hashId } = parseRoute();
+  activeRoute = page || null;
 
-  const sectionIds = ["drop", "lookbook", "shop", "about"];  
-  const sections = sectionIds.map((id) => document.getElementById(id)).filter(Boolean);  
+  if (page === "lookbook") {
+    showRoute("lookbook");
+    renderLookbookRoute(lookbookIndex);
+    document.title = `FAIDE | Lookbook ${activeLookbookIndex}`;
+    return;
+  }
 
-  function setActive(id) {  
-    navLinks.forEach((a) => {  
-      a.classList.remove("active");  
-      a.removeAttribute("aria-current");  
-    });  
-    Array.from(navLinks)  
-      .filter((a) => (a.getAttribute("href") || "").endsWith(`#${id}`))  
-      .forEach((lnk) => {  
-        lnk.classList.add("active");  
-        lnk.setAttribute("aria-current", "page");  
-      });  
-  }  
+  if (page === "product") {
+    showRoute("product");
+    await renderProductRoute(productId);
+    document.title = rppProduct ? `FAIDE | ${rppProduct.name}` : "FAIDE | Product";
+    return;
+  }
 
-  let navLock = false;  
-  let navUnlockTimer = null;  
+  showRoute(null);
+  document.title = "FAIDE | Luxury Streetwear Brand";
+  updateActiveFromScroll();
 
-  navLinks.forEach((a) => {  
-    a.addEventListener("click", (e) => {  
-      const href = a.getAttribute("href") || "";  
-      if (!href.includes("#")) return;  
-      const id = href.split("#")[1];  
-      if (!id) return;  
+  if (hashId && ["drop", "lookbook", "shop", "about", "footer"].includes(hashId)) {
+    setTimeout(() => {
+      scrollToSectionId(hashId);
+      setActive(hashId === "footer" ? "about" : hashId);
+    }, 30);
+  }
+}
 
-      e.preventDefault();  
-      navLock = true;  
-      clearTimeout(navUnlockTimer);  
+navLinks.forEach((a) => {
+  a.addEventListener("click", (e) => {
+    const href = a.getAttribute("href") || "";
+    if (!href.includes("#")) return;
+    const id = href.split("#")[1];
+    if (!id) return;
 
-      setActive(id);  
-      scrollToSectionId(id);  
+    e.preventDefault();
+    navLock = true;
+    clearTimeout(navUnlockTimer);
+    setActive(id);
 
-      navUnlockTimer = setTimeout(() => (navLock = false), 650);  
-      history.replaceState(null, "", `${location.pathname}#${id}`);  
-    });  
-  });  
+    if (activeRoute) {
+      gotoHomeSection(id);
+    } else {
+      scrollToSectionId(id);
+      history.replaceState({}, "", `${location.pathname}#${id}`);
+    }
 
-  let raf = null;  
-  const updateActiveFromScroll = () => {  
-    if (navLock) return;  
-    const refY = window.scrollY + getNavOffsetPx() + 10;  
-    let current = sections[0]?.id || "drop";  
-    for (const sec of sections) if (sec && sec.offsetTop <= refY) current = sec.id;  
-    setActive(current);  
-  };  
+    navUnlockTimer = setTimeout(() => (navLock = false), 650);
+  });
+});
 
-  const onScroll = () => {  
-    if (raf) return;  
-    raf = requestAnimationFrame(() => {  
-      raf = null;  
-      updateActiveFromScroll();  
-    });  
-  };  
+rlbPrev?.addEventListener("click", () => {
+  const total = (catalog.lookbook || []).length || 1;
+  const next = activeLookbookIndex <= 1 ? total : activeLookbookIndex - 1;
+  gotoLookbook(next);
+});
+rlbNext?.addEventListener("click", () => {
+  const total = (catalog.lookbook || []).length || 1;
+  const next = activeLookbookIndex >= total ? 1 : activeLookbookIndex + 1;
+  gotoLookbook(next);
+});
 
-  updateActiveFromScroll();  
-  window.addEventListener("scroll", onScroll, { passive: true });  
-  window.addEventListener("resize", updateActiveFromScroll, { passive: true });  
+window.addEventListener("scroll", onScroll, { passive: true });
+window.addEventListener("resize", updateActiveFromScroll, { passive: true });
+window.addEventListener("faide:navigate", () => {
+  applyRoute();
+});
 
-  const hashId = (location.hash || "").replace("#", "");  
-  if (hashId && ["drop", "lookbook", "shop", "about", "footer"].includes(hashId)) {  
-    setTimeout(() => {  
-      scrollToSectionId(hashId);  
-      setActive(hashId === "footer" ? "about" : hashId);  
-    }, 30);  
-  }  
-}  
+await applyRoute();
 
 // Product route add to cart  
 rpp.add?.addEventListener("click", () => {  
@@ -1245,7 +1390,7 @@ function alreadySignedUp() {
   }  
 }  
 
-if (!page && !alreadySignedUp()) {  
+if (!activeRoute && !alreadySignedUp()) {  
   const shopSection = document.getElementById("shop");  
   if (shopSection && "IntersectionObserver" in window) {  
     const obs = new IntersectionObserver(  
@@ -1264,11 +1409,17 @@ if (!page && !alreadySignedUp()) {
 
 // ---------- Back gesture: close open layers first ----------  
 window.addEventListener("popstate", () => {  
-  if ($("signup-modal")?.style.display === "block") return signupModal.close();  
-  if ($("checkout-modal")?.style.display === "block") return checkoutModal.close();  
+  if (ignoreNextPop) {
+    ignoreNextPop = false;
+    return;
+  }
+  if ($("login-modal")?.style.display === "block") return loginModal.close(true);
+  if ($("signup-modal")?.style.display === "block") return signupModal.close(true);  
+  if ($("checkout-modal")?.style.display === "block") return checkoutModal.close(true);  
   if ($("policy-modal")?.style.display === "block") return policies.close();  
-  if ($("cart-sidebar")?.classList.contains("active")) return closeCartPanel();  
-  if (drawer?.classList.contains("open")) return closeDrawer();  
+  if ($("cart-sidebar")?.classList.contains("active")) return closeCartPanel(true);  
+  if (drawer?.classList.contains("open")) return closeDrawer(true);  
+  applyRoute();
 });  
 
 // ESC handling  
@@ -1277,6 +1428,7 @@ document.addEventListener("keydown", (e) => {
 
   if (drawer?.classList.contains("open")) closeDrawer();  
   if ($("policy-modal")?.style.display === "block") policies.close();  
+  if ($("login-modal")?.style.display === "block") loginModal.close();
   if ($("checkout-modal")?.style.display === "block") checkoutModal.close();  
   if ($("signup-modal")?.style.display === "block") signupModal.close();  
   if ($("cart-sidebar")?.classList.contains("active")) closeCartPanel();  

--- a/public/assets/js/products.json
+++ b/public/assets/js/products.json
@@ -1,7 +1,15 @@
 {
   "lookbook": [
-    { "id": 1, "image": "images/lookbook1.png", "alt": "FAIDE Lookbook 1" },
-    { "id": 2, "image": "images/lookbook2.png", "alt": "FAIDE Lookbook 2" }
+    {
+      "id": 1,
+      "image": "images/lookbook1.png",
+      "alt": "FAIDE Lookbook 1"
+    },
+    {
+      "id": 2,
+      "image": "images/lookbook2.png",
+      "alt": "FAIDE Lookbook 2"
+    }
   ],
   "products": [
     {
@@ -11,12 +19,28 @@
       "category": "UNISEX Tank Top",
       "price": 199.99,
       "currencySymbol": "R",
-      "sizes": ["S", "M", "L", "XL"],
-      "colors": [
-        { "name": "Black", "className": "color black" },
-        { "name": "White", "className": "color white" }
+      "sizes": [
+        "S",
+        "M",
+        "L",
+        "XL"
       ],
-      "images": ["images/tank-top.png", "images/tank-top1.png", "images/tank-top2.png", "images/tank-top3.png"]
+      "colors": [
+        {
+          "name": "Black",
+          "className": "color black"
+        },
+        {
+          "name": "White",
+          "className": "color white"
+        }
+      ],
+      "images": [
+        "images/tank-top.png",
+        "images/tank-top1.png",
+        "images/tank-top2.png",
+        "images/tank-top3.png"
+      ]
     },
     {
       "id": "tee",
@@ -25,13 +49,32 @@
       "category": "UNISEX Short-Sleeve Top",
       "price": 349.99,
       "currencySymbol": "R",
-      "sizes": ["S", "M", "L", "XL"],
-      "colors": [
-        { "name": "Black", "className": "color black" },
-        { "name": "White", "className": "color white" },
-        { "name": "Grey", "className": "color grey" }
+      "sizes": [
+        "S",
+        "M",
+        "L",
+        "XL"
       ],
-      "images": ["images/tshirt.png", "images/tshirt1.png", "images/tshirt2.png", "images/tshirt3.png"]
+      "colors": [
+        {
+          "name": "Black",
+          "className": "color black"
+        },
+        {
+          "name": "White",
+          "className": "color white"
+        },
+        {
+          "name": "Grey",
+          "className": "color grey"
+        }
+      ],
+      "images": [
+        "images/tshirt.png",
+        "images/tshirt1.png",
+        "images/tshirt2.png",
+        "images/tshirt3.png"
+      ]
     },
     {
       "id": "longsleeve",
@@ -40,12 +83,28 @@
       "category": "UNISEX Long Sleeve",
       "price": 549.99,
       "currencySymbol": "R",
-      "sizes": ["S", "M", "L", "XL"],
-      "colors": [
-        { "name": "Black", "className": "color black" },
-        { "name": "White", "className": "color white" }
+      "sizes": [
+        "S",
+        "M",
+        "L",
+        "XL"
       ],
-      "images": ["images/longsleeve.png", "images/longsleeve1.png", "images/longsleeve2.png", "images/longsleeve3.png"]
+      "colors": [
+        {
+          "name": "Black",
+          "className": "color black"
+        },
+        {
+          "name": "White",
+          "className": "color white"
+        }
+      ],
+      "images": [
+        "images/longsleeve.png",
+        "images/longsleeve1.png",
+        "images/longsleeve2.png",
+        "images/longsleeve3.png"
+      ]
     },
     {
       "id": "hoodie",
@@ -54,12 +113,28 @@
       "category": "UNISEX Pullover Hoodie",
       "price": 699.99,
       "currencySymbol": "R",
-      "sizes": ["S", "M", "L", "XL"],
-      "colors": [
-        { "name": "Black", "className": "color black" },
-        { "name": "White", "className": "color white" }
+      "sizes": [
+        "S",
+        "M",
+        "L",
+        "XL"
       ],
-      "images": ["images/hoodie.png", "images/hoodie1.png", "images/hoodie2.png", "images/hoodie3.png"]
+      "colors": [
+        {
+          "name": "Black",
+          "className": "color black"
+        },
+        {
+          "name": "White",
+          "className": "color white"
+        }
+      ],
+      "images": [
+        "images/hoodie.png",
+        "images/hoodie1.png",
+        "images/hoodie2.png",
+        "images/hoodie3.png"
+      ]
     },
     {
       "id": "beanie",
@@ -68,15 +143,22 @@
       "category": "UNISEX Beanie",
       "price": 119.99,
       "currencySymbol": "R",
-
-      "sizes": ["One Size"],
-
-      "colors": [
-        { "name": "Black", "className": "color black" },
-        { "name": "White", "className": "color white" }
+      "sizes": [
+        "One Size"
       ],
-
-      "images": ["images/beanie.jpg", "images/beanie1.png", "images/beanie2.png", "images/beanie3.png"]
+      "colors": [
+        {
+          "name": "Black",
+          "className": "color black"
+        },
+        {
+          "name": "White",
+          "className": "color white"
+        }
+      ],
+      "images": [
+        "images/beanie.jpg"
+      ]
     }
   ]
 }

--- a/public/index.html
+++ b/public/index.html
@@ -15,7 +15,7 @@
     <meta name="theme-color" content="#000000" />  
   
     <link rel="icon" href="favicon.png" />  
-    <link rel="apple-touch-icon" href="apple-touch-icon.png" />  
+    <link rel="apple-touch-icon" href="favicon.png" />  
   
     <link rel="preload" as="image" href="images/hero.png" />  
     <link rel="preload" as="image" href="images/faide-wordmark.png" />  
@@ -140,6 +140,10 @@
         <a href="#shop" data-nav-link="main">SHOP</a>  
         <a href="#about" data-nav-link="main">ABOUT</a>  
       </div>  
+      <div class="drawer-footer">
+        <button id="drawer-login-btn" class="drawer-login-btn" type="button">Login</button>
+        <p class="drawer-note">Track saved details, drops, and your bag.</p>
+      </div>
     </aside>  
   
     <!-- ROUTE: LOOKBOOK (query route ?page=lookbook&i=1) -->  
@@ -164,8 +168,11 @@
         </div>  
   
         <div class="lookbook-view">  
+          <button type="button" class="route-arrow route-arrow-left" id="rlb-prev" aria-label="Previous lookbook image">‹</button>
           <img id="rlb-img" alt="Lookbook image" src="" />  
-        </div>  
+          <button type="button" class="route-arrow route-arrow-right" id="rlb-next" aria-label="Next lookbook image">›</button>
+        </div>
+        <div class="route-meta" id="rlb-meta"></div>  
       </div>  
     </main>  
   
@@ -225,7 +232,7 @@
   
             <button type="button" class="secondary-btn" id="rpp-add" disabled>Add to Bag</button>  
   
-            <div class="rpp-hint">Tap thumbnails • Select size &amp; color • Add to Bag</div>  
+            <div class="rpp-hint">Choose a size and color, then add it to your bag.</div>  
           </div>  
         </section>  
       </div>  
@@ -404,7 +411,10 @@
   
     <div id="cart-sidebar" class="cart-sidebar" aria-label="Shopping cart">  
       <div class="cart-header">  
-        <h2>Your Cart</h2>  
+        <div>
+          <p class="cart-kicker">Bag</p>
+          <h2>Your Cart</h2>
+        </div>
         <button id="close-cart" class="close-cart" aria-label="Close cart" type="button">  
           <svg width="24" height="24" fill="currentColor" viewBox="0 0 24 24" aria-hidden="true">  
             <path  
@@ -414,16 +424,32 @@
         </button>  
       </div>  
   
-      <ul id="cart-items" class="cart-items"></ul>  
+      <div class="cart-body">
+        <div class="cart-summary-card">
+          <div>
+            <div class="cart-summary-label">Items</div>
+            <div id="cart-summary-count" class="cart-summary-value">0 pieces</div>
+          </div>
+          <div>
+            <div class="cart-summary-label">Subtotal</div>
+            <div class="cart-summary-value">R<span id="cart-summary-total">0.00</span></div>
+          </div>
+        </div>
+        <ul id="cart-items" class="cart-items"></ul>  
+      </div>
   
       <div class="cart-footer">  
+        <div class="cart-meta">
+          <span>Secure checkout upgrade coming soon</span>
+          <span>Saved locally on this device</span>
+        </div>
         <div class="cart-total-row">  
           <span class="cart-total-label">Total:</span>  
           <span class="cart-total-value">R<span id="cart-total">0.00</span></span>  
         </div>  
   
         <button class="checkout-btn" id="checkout-btn" type="button" disabled title="Add items to checkout">  
-          Proceed to Checkout  
+          Continue to Checkout  
         </button>  
       </div>  
     </div>  
@@ -452,44 +478,56 @@
   
         <div class="modal-body">  
           <div class="checkout-banner">  
-            <div class="checkout-banner-title">Card Payments: Coming Soon</div>  
+            <div class="checkout-banner-title">Checkout Preview</div>  
             <div class="checkout-banner-text">  
-              We’re finishing secure card checkout. For now, you can view your cart here and we’ll enable payments soon.  
+              Save your delivery details now and we will keep your next checkout fast on this device.  
             </div>  
           </div>  
-  
-          <div class="checkout-summary">  
-            <div class="checkout-summary-row">  
-              <span class="checkout-muted">Items</span>  
-              <span id="checkout-items-count" class="checkout-strong">0</span>  
+
+          <div class="checkout-layout">
+            <div class="checkout-summary checkout-summary-primary">  
+              <div class="checkout-summary-row">  
+                <span class="checkout-muted">Items</span>  
+                <span id="checkout-items-count" class="checkout-strong">0</span>  
+              </div>  
+              <div class="checkout-summary-row">  
+                <span class="checkout-muted">Subtotal</span>  
+                <span class="checkout-strong">R<span id="checkout-total">0.00</span></span>  
+              </div>  
+              <div class="checkout-summary-row">
+                <span class="checkout-muted">Shipping</span>
+                <span class="checkout-strong">Calculated at launch</span>
+              </div>
+              <div class="checkout-summary-row checkout-summary-total">
+                <span class="checkout-muted">Estimated total</span>
+                <span class="checkout-strong">R<span id="checkout-total-estimate">0.00</span></span>
+              </div>
             </div>  
-            <div class="checkout-summary-row">  
-              <span class="checkout-muted">Total</span>  
-              <span class="checkout-strong">R<span id="checkout-total">0.00</span></span>  
+
+            <div class="checkout-form">  
+              <div class="checkout-form-title">Delivery details</div>  
+              <div class="checkout-grid">  
+                <input id="co-name" type="text" placeholder="Full name" autocomplete="name" />  
+                <input id="co-email" type="email" placeholder="Email" autocomplete="email" />  
+                <input id="co-phone" type="tel" placeholder="Phone number" autocomplete="tel" />  
+                <input id="co-city" type="text" placeholder="City" autocomplete="address-level2" />  
+              </div>  
+              <div class="checkout-grid checkout-grid-single">
+                <input id="co-address" type="text" placeholder="Delivery address" autocomplete="street-address" />
+              </div>
+              <button id="co-submit" type="button" class="secondary-btn">  
+                Save Details  
+              </button>  
+
+              <div class="checkout-note">  
+                Your information stays on this device until live checkout is ready.  
+              </div>  
             </div>  
-          </div>  
-  
-          <div class="checkout-form">  
-            <div class="checkout-form-title">Get notified when payments go live</div>  
-            <div class="checkout-grid">  
-              <input id="co-name" type="text" placeholder="Full name" autocomplete="name" />  
-              <input id="co-email" type="email" placeholder="Email" autocomplete="email" />  
-              <input id="co-phone" type="tel" placeholder="Phone (optional)" autocomplete="tel" />  
-              <input id="co-city" type="text" placeholder="City (optional)" autocomplete="address-level2" />  
-            </div>  
-  
-            <button id="co-submit" type="button" class="secondary-btn">  
-              Save My Details  
-            </button>  
-  
-            <div class="checkout-note">  
-              This does not place an order yet. It only saves your details locally on this device for faster checkout later.  
-            </div>  
-          </div>  
+          </div>
   
           <div class="checkout-actions">  
-            <button id="checkout-close-2" type="button" class="ghost-btn">Close</button>  
-            <button type="button" class="checkout-pay-btn" disabled title="Coming soon">Pay with Card (Coming Soon)</button>  
+            <button id="checkout-close-2" type="button" class="ghost-btn">Keep Shopping</button>  
+            <button type="button" class="checkout-pay-btn" disabled title="Coming soon">Secure Card Checkout Coming Soon</button>  
           </div>  
         </div>  
       </div>  
@@ -520,18 +558,54 @@
         <div class="modal-body">  
           <div class="signup-banner">  
             <div class="signup-title">Get early access to drops</div>  
-            <div class="signup-text">Enter your email to get exclusive updates, early access, and drop alerts.</div>  
+            <div class="signup-text">Join the list for release reminders, low-stock notices, and launch-day access.</div>  
           </div>  
   
           <div class="signup-form">  
+            <input id="su-name" type="text" placeholder="First name" autocomplete="given-name" />
             <input id="su-email" type="email" placeholder="Email address" autocomplete="email" />  
-            <button id="su-submit" type="button" class="secondary-btn">Sign Up</button>  
-            <div class="signup-note">We won’t spam you. You can unsubscribe anytime.</div>  
+            <button id="su-submit" type="button" class="secondary-btn">Join the List</button>  
+            <button id="su-later" type="button" class="ghost-btn signup-later-btn">Maybe Later</button>
+            <div class="signup-note">One tap to close, no spam.</div>  
           </div>  
         </div>  
       </div>  
     </div>  
   
+
+    <!-- LOGIN MODAL -->
+    <div
+      id="login-modal"
+      class="modal-overlay"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="login-title"
+      style="display:none;"
+    >
+      <div class="modal-card modal-card-narrow">
+        <div class="modal-head">
+          <h2 id="login-title" class="modal-title">Login</h2>
+          <button id="login-close" type="button" class="modal-close" aria-label="Close login">
+            <svg width="24" height="24" fill="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+              <path d="M23.954 21.03l-9.184-9.095 9.092-9.174-2.832-2.807-9.09 9.179-9.176-9.088-2.81 2.81 9.186 9.105-9.095 9.184 2.81 2.81 9.112-9.192 9.18 9.1z" />
+            </svg>
+          </button>
+        </div>
+        <div class="modal-body">
+          <div class="signup-banner">
+            <div class="signup-title">Welcome back</div>
+            <div class="signup-text">Sign in to keep your saved details ready for new drops and faster checkout.</div>
+          </div>
+          <div class="signup-form">
+            <input id="login-email" type="email" placeholder="Email address" autocomplete="email" />
+            <input id="login-password" type="password" placeholder="Password" autocomplete="current-password" />
+            <button id="login-submit" type="button" class="secondary-btn">Login</button>
+            <div class="signup-note">Demo login saves your session on this device.</div>
+          </div>
+        </div>
+      </div>
+    </div>
+
     <!-- Toast -->  
     <div class="cart-toast" id="cartToast" role="status" aria-live="polite">  
       <svg width="20" height="20" fill="currentColor" viewBox="0 0 24 24" aria-hidden="true">  


### PR DESCRIPTION
### Motivation
- Improve single-page UX by moving to client-side routing and history navigation to avoid full page reloads for lookbook/product routes and enable back-gesture handling on mobile.
- Make cart and checkout flows more useful by adding local save for checkout details, clearer subtotal UI, and inline validation for saved info.
- Add a lightweight login flow and polish mobile drawer/lookbook/product UI for better accessibility and touch experience.

### Description
- Refactored routing in `public/assets/js/app.js` to use history APIs with `navigateTo`, `applyRoute`, and `parseRoute`, and introduced `faide:navigate` events to keep routes in sync without full reloads. 
- Reworked modal and overlay state management with modal stacking and history integration via `pushModalState`, `requestHistoryBack`, `consumeModalDepth`, `syncLockState`, and `anyLayerOpen` to support mobile back gestures and consistent `lock-scroll` behavior.
- Added login support and session persistence with a new `initLoginModal` and `LOGIN_STORAGE_KEY`, plus form validation helper `isValidEmail` and basic client-side validation for signup and checkout forms; signup now captures `name` and offers a "Maybe Later" action.
- Enhanced cart and checkout UI and behavior: cart summary card and meta in the sidebar, syncable totals via `checkoutModal.syncTotals`, improved empty-cart messaging, and added checkout fields (address) with local persistence under `CHECKOUT_PROFILE_KEY` and refined copy. 
- UI/CSS updates in `public/assets/css/style.css` and `public/index.html` include drawer footer/login button, lookbook grid with prev/next arrows and metadata, responsive arrow sizing, new modal narrow layout, checkout two-column layout, updated copy, and various spacing/visual tweaks. 
- Minor content/formatting updates in `public/assets/js/products.json` (product data array formatting and images) and small text updates across templates (e.g., `rpp-hint`, checkout button label). 

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bda6f270e08325b3035882e04c4bae)