### PR TITLE
UI/UX: shipping strip, navbar layout, reveal removal, product/cart copy and signup/login persistence

### DIFF
--- a/public/assets/css/style.css
+++ b/public/assets/css/style.css
@@ -1837,3 +1837,184 @@ body.nav-hidden #navbar {
     opacity: 1 !important;
   }
 }
+
+/* ===== Requested UI adjustments ===== */
+.shipping-strip {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  z-index: 1100;
+  text-align: center;
+  font-size: 0.72rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  padding: 8px 12px;
+  color: #fff;
+  background: rgba(0, 0, 0, 0.72);
+  border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.navbar {
+  top: 34px;
+  background: transparent !important;
+  backdrop-filter: none !important;
+  border-bottom: none !important;
+  display: grid;
+  grid-template-columns: 44px 1fr 44px;
+  align-items: center;
+}
+
+.brand-link {
+  position: absolute;
+  left: 50%;
+  transform: translateX(-50%);
+}
+
+.nav-links {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  overflow: hidden;
+  clip-path: inset(50%);
+  white-space: nowrap;
+}
+
+.nav-menu-btn { justify-self: start; }
+.nav-cart-btn { justify-self: end; position: relative; }
+.cart-count-nav {
+  width: 18px;
+  height: 18px;
+  font-size: 0.62rem;
+  top: -3px;
+  right: -3px;
+  border-width: 1px;
+}
+
+.hero {
+  padding-top: calc(var(--nav-h) + 130px);
+}
+
+.route-page {
+  padding-top: 0;
+}
+
+body.route-open #navbar,
+body.route-open .shipping-strip {
+  display: none;
+}
+
+.route-page.active {
+  min-height: 100dvh;
+  background: #000;
+}
+
+.product-stock-pill,
+.rpp-stock {
+  font-size: 0.62rem;
+  padding: 5px 8px;
+  letter-spacing: 0.04em;
+}
+
+.product-status-tag {
+  display: none !important;
+}
+
+.footer,
+.footer * {
+  color: #7A7A7A !important;
+}
+
+.signup-modal-card {
+  max-width: 460px;
+}
+
+@media (max-width: 768px) {
+  .signup-modal-card {
+    width: min(92vw, 420px);
+    max-width: min(92vw, 420px);
+    height: auto;
+    min-height: 0;
+    margin: 10vh auto 0;
+    border-radius: 14px;
+  }
+
+  .navbar {
+    top: 32px;
+  }
+}
+
+/* remove fades/reveals */
+.fade-in-up,
+.reveal-on-scroll,
+.reveal-on-scroll.in-view,
+.lookbook-card,
+.product,
+.modal-card,
+.cart-sidebar,
+.checkout-step-chip {
+  animation: none !important;
+  transition: none !important;
+  transform: none !important;
+  opacity: 1 !important;
+}
+
+
+/* ===== follow-up fixes ===== */
+.shipping-strip {
+  background: #7a7a7a;
+  color: #fff;
+}
+
+.navbar {
+  grid-template-columns: 44px 1fr auto;
+}
+
+.nav-right-actions {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  justify-self: end;
+}
+
+.nav-icon-btn {
+  border: none;
+  background: transparent;
+  border-radius: 0;
+}
+
+.nav-icon-btn:hover,
+.nav-icon-btn:active {
+  background: transparent;
+  transform: none;
+}
+
+@media (min-width: 769px) {
+  .nav-icon-btn {
+    width: 32px;
+    height: 32px;
+    padding: 0;
+  }
+}
+
+@media (max-width: 768px) {
+  .nav-icon-btn {
+    width: 40px;
+    height: 40px;
+  }
+}
+
+.drawer {
+  right: -320px;
+  left: auto;
+  border-right: none;
+}
+
+.hero-bg::after,
+.lookbook-card::before {
+  display: none;
+}
+
+.modal-card-policy .modal-eyebrow {
+  display: none;
+}

--- a/public/assets/js/app.js
+++ b/public/assets/js/app.js
@@ -168,12 +168,17 @@
       if (site) site.style.display = "none";
       rlb?.classList.add("active");
       rlb?.setAttribute("aria-hidden", "false");
+      document.body.classList.add("route-open");
+      return;
     }
     if (page === "product") {
       if (site) site.style.display = "none";
       rpp?.classList.add("active");
       rpp?.setAttribute("aria-hidden", "false");
+      document.body.classList.add("route-open");
+      return;
     }
+    document.body.classList.remove("route-open");
   }
 
   function normalizeStr(s) {
@@ -251,6 +256,7 @@
   const CHECKOUT_PROFILE_KEY = "faide_checkout_profile_v1";
   const SIGNUP_KEY = "faide_signup_v2";
   const AUTH_KEY = "faide_auth_v1";
+  const USERS_KEY = "faide_users_v1";
 
   function loadJsonStorage(key, fallback) {
     try {
@@ -332,8 +338,8 @@
 
   function stockMessage(product, settings) {
     return productIsAvailable(product, settings)
-      ? (product?.stockNote || settings?.stockMessage || "Ready to ship")
-      : (settings?.outOfStockMessage || product?.outOfStockMessage || "Out of stock");
+      ? (product?.stockNote || settings?.stockMessage || "In stock")
+      : (settings?.outOfStockMessage || product?.outOfStockMessage || "Out");
   }
 
   function preloadImage(src, priority = "auto") {
@@ -597,9 +603,26 @@
         showCartToast("Enter a valid email and at least 6 characters.");
         return;
       }
-      const payload = { email: userEmail, password: userPassword, mode, ts: Date.now() };
-      saveJsonStorage(mode === "login" ? AUTH_KEY : SIGNUP_KEY, payload);
-      showCartToast(mode === "login" ? "Welcome back to FAIDE." : "You’re in. Drop alerts enabled.");
+      const users = loadJsonStorage(USERS_KEY, []);
+      if (mode === "signup") {
+        if (users.some((u) => u.email === userEmail)) {
+          showCartToast("Email already registered. Log in instead.");
+          return;
+        }
+        users.push({ email: userEmail, password: userPassword, ts: Date.now() });
+        saveJsonStorage(USERS_KEY, users);
+        saveJsonStorage(SIGNUP_KEY, { email: userEmail, ts: Date.now() });
+        saveJsonStorage(AUTH_KEY, { email: userEmail, ts: Date.now() });
+        showCartToast("You’re in. Account saved on this device.");
+      } else {
+        const match = users.find((u) => u.email === userEmail && u.password === userPassword);
+        if (!match) {
+          showCartToast("Account not found. Check details or sign up.");
+          return;
+        }
+        saveJsonStorage(AUTH_KEY, { email: userEmail, ts: Date.now() });
+        showCartToast("Welcome back to FAIDE.");
+      }
       closeOverlay("auth");
     });
 
@@ -659,7 +682,7 @@
         <div class="product-info">
           <div class="product-label-row">
             <div class="product-label">${p.label || "New"}</div>
-            ${available ? "" : '<div class="product-status-tag">Unavailable</div>'}
+            
           </div>
           <div class="product-header">
             <div class="product-name-wrapper">
@@ -681,7 +704,7 @@
                 <button type="button" class="qty-btn-ui" data-qty-btn="inc" aria-label="Increase quantity">+</button>
               </div>
             </div>
-            <button type="button" class="secondary-btn add-to-cart" ${available ? "disabled" : "disabled data-disabled-reason=\"out-of-stock\""}>${available ? "Add to Bag" : "Out of Stock"}</button>
+            <button type="button" class="secondary-btn add-to-cart" ${available ? "disabled" : "disabled data-disabled-reason=\"out-of-stock\""}>${available ? "Add to Bag" : "Sold out"}</button>
           </div>
         </div>`;
       shopEl.appendChild(card);
@@ -689,19 +712,7 @@
   }
 
   function initRevealAnimations() {
-    if (window.matchMedia("(prefers-reduced-motion: reduce)").matches) return;
-    const targets = document.querySelectorAll(".lookbook-card, .product, .section-title, .about, .checkout-banner, .checkout-support-card, .cart-intro-card");
-    const observer = new IntersectionObserver((entries) => {
-      entries.forEach((entry) => {
-        if (!entry.isIntersecting) return;
-        entry.target.classList.add("in-view");
-        observer.unobserve(entry.target);
-      });
-    }, { threshold: 0.14, rootMargin: "0px 0px -40px 0px" });
-    targets.forEach((el) => {
-      el.classList.add("reveal-on-scroll");
-      observer.observe(el);
-    });
+    return;
   }
 
   document.addEventListener("DOMContentLoaded", async () => {
@@ -717,7 +728,7 @@
 
     $("mobile-search-btn")?.addEventListener("click", () => {
       scrollToSectionId("shop");
-      setTimeout(() => shopSearchInput?.focus?.(), 400);
+      setTimeout(() => shopSearchInput?.focus?.(), 250);
     });
 
     function handleShrink() {
@@ -791,7 +802,7 @@
     renderShop($("shop-products"), catalog.products || [], catalog.settings || {});
     initRevealAnimations();
 
-    const floatingCart = $("floating-cart");
+    const floatingCart = $("nav-cart-btn");
     const cartSidebar = $("cart-sidebar");
     const cartOverlay = $("cart-overlay");
     const cartItemsEl = $("cart-items");
@@ -842,11 +853,11 @@
       const totals = getCartTotals();
       cartTotalEl.textContent = totals.total.toFixed(2);
       cartCountEl.textContent = String(totals.itemCount);
-      if (cartSummaryEl) cartSummaryEl.textContent = totals.itemCount ? `${totals.itemCount} item${totals.itemCount === 1 ? "" : "s"} ready for checkout` : "Your bag is empty";
+      if (cartSummaryEl) cartSummaryEl.textContent = totals.itemCount ? `${totals.itemCount} item${totals.itemCount === 1 ? "" : "s"}` : "Bag empty";
       if (checkoutBtn) checkoutBtn.disabled = cart.length === 0;
 
       if (cart.length === 0) {
-        cartItemsEl.innerHTML = '<li class="cart-empty-state"><strong>Your bag is empty.</strong><span>Add a piece from the drop to start your checkout.</span></li>';
+        cartItemsEl.innerHTML = '<li class="cart-empty-state"><strong>Bag empty.</strong><span>Add a piece to continue.</span></li>';
         return;
       }
 

--- a/public/assets/js/products.json
+++ b/public/assets/js/products.json
@@ -1,8 +1,8 @@
 {
   "settings": {
     "inventoryMode": "in_stock",
-    "stockMessage": "Ready to ship",
-    "outOfStockMessage": "Currently out of stock"
+    "stockMessage": "In stock",
+    "outOfStockMessage": "Out"
   },
   "lookbook": [
     {
@@ -25,9 +25,28 @@
       "price": 199.99,
       "currencySymbol": "R",
       "inStock": false,
-      "sizes": ["S", "M", "L", "XL"],
-      "colors": [{ "name": "Black", "className": "color black" }, { "name": "White", "className": "color white" }],
-      "images": ["images/tank-top.png", "images/tank-top1.png", "images/tank-top2.png", "images/tank-top3.png"]
+      "sizes": [
+        "S",
+        "M",
+        "L",
+        "XL"
+      ],
+      "colors": [
+        {
+          "name": "Black",
+          "className": "color black"
+        },
+        {
+          "name": "White",
+          "className": "color white"
+        }
+      ],
+      "images": [
+        "images/tank-top.png",
+        "images/tank-top1.png",
+        "images/tank-top2.png",
+        "images/tank-top3.png"
+      ]
     },
     {
       "id": "tee",
@@ -37,9 +56,32 @@
       "price": 349.99,
       "currencySymbol": "R",
       "inStock": false,
-      "sizes": ["S", "M", "L", "XL"],
-      "colors": [{ "name": "Black", "className": "color black" }, { "name": "White", "className": "color white" }, { "name": "Grey", "className": "color grey" }],
-      "images": ["images/tshirt.png", "images/tshirt1.png", "images/tshirt2.png", "images/tshirt3.png"]
+      "sizes": [
+        "S",
+        "M",
+        "L",
+        "XL"
+      ],
+      "colors": [
+        {
+          "name": "Black",
+          "className": "color black"
+        },
+        {
+          "name": "White",
+          "className": "color white"
+        },
+        {
+          "name": "Grey",
+          "className": "color grey"
+        }
+      ],
+      "images": [
+        "images/tshirt.png",
+        "images/tshirt1.png",
+        "images/tshirt2.png",
+        "images/tshirt3.png"
+      ]
     },
     {
       "id": "longsleeve",
@@ -49,9 +91,28 @@
       "price": 549.99,
       "currencySymbol": "R",
       "inStock": false,
-      "sizes": ["S", "M", "L", "XL"],
-      "colors": [{ "name": "Black", "className": "color black" }, { "name": "White", "className": "color white" }],
-      "images": ["images/longsleeve.png", "images/longsleeve1.png", "images/longsleeve2.png", "images/longsleeve3.png"]
+      "sizes": [
+        "S",
+        "M",
+        "L",
+        "XL"
+      ],
+      "colors": [
+        {
+          "name": "Black",
+          "className": "color black"
+        },
+        {
+          "name": "White",
+          "className": "color white"
+        }
+      ],
+      "images": [
+        "images/longsleeve.png",
+        "images/longsleeve1.png",
+        "images/longsleeve2.png",
+        "images/longsleeve3.png"
+      ]
     },
     {
       "id": "hoodie",
@@ -61,9 +122,28 @@
       "price": 699.99,
       "currencySymbol": "R",
       "inStock": false,
-      "sizes": ["S", "M", "L", "XL"],
-      "colors": [{ "name": "Black", "className": "color black" }, { "name": "White", "className": "color white" }],
-      "images": ["images/hoodie.png", "images/hoodie1.png", "images/hoodie2.png", "images/hoodie3.png"]
+      "sizes": [
+        "S",
+        "M",
+        "L",
+        "XL"
+      ],
+      "colors": [
+        {
+          "name": "Black",
+          "className": "color black"
+        },
+        {
+          "name": "White",
+          "className": "color white"
+        }
+      ],
+      "images": [
+        "images/hoodie.png",
+        "images/hoodie1.png",
+        "images/hoodie2.png",
+        "images/hoodie3.png"
+      ]
     },
     {
       "id": "beanie",
@@ -73,9 +153,52 @@
       "price": 119.99,
       "currencySymbol": "R",
       "inStock": false,
-      "sizes": ["One Size"],
-      "colors": [{ "name": "Black", "className": "color black" }, { "name": "White", "className": "color white" }],
-      "images": ["images/beanie.jpg"]
+      "sizes": [
+        "One Size"
+      ],
+      "colors": [
+        {
+          "name": "Black",
+          "className": "color black"
+        },
+        {
+          "name": "White",
+          "className": "color white"
+        }
+      ],
+      "images": [
+        "images/beanie.jpg"
+      ]
+    },
+    {
+      "id": "tracksuit",
+      "name": "FAIDE Track Suit",
+      "label": "New",
+      "category": "UNISEX Track Suit",
+      "price": 899.99,
+      "currencySymbol": "R",
+      "inStock": true,
+      "sizes": [
+        "S",
+        "M",
+        "L",
+        "XL"
+      ],
+      "colors": [
+        {
+          "name": "Black",
+          "className": "color black"
+        },
+        {
+          "name": "Grey",
+          "className": "color grey"
+        }
+      ],
+      "images": [
+        "images/hoodie.png",
+        "images/hoodie1.png",
+        "images/hoodie2.png"
+      ]
     }
   ]
 }

--- a/public/index.html
+++ b/public/index.html
@@ -102,42 +102,49 @@
   
   <body>  
     <!-- NAV -->  
-    <nav class="navbar" id="navbar">  
-      <a href="#drop" aria-label="FAIDE Home" class="brand-link">  
-        <img src="images/faide-wordmark.png" alt="FAIDE" class="faide-wordmark-img" id="brand-wordmark" />  
-      </a>  
-  
-      <div class="nav-links" aria-label="Primary navigation">  
-        <a href="#drop" data-nav-link="main">NEW DROP</a>  
-        <a href="#lookbook" data-nav-link="main">LOOKBOOK</a>  
-        <a href="#shop" data-nav-link="main">SHOP</a>  
-        <a href="#about" data-nav-link="main">ABOUT</a>  
-      </div>  
-  
-      <div class="nav-mobile-actions" aria-label="Mobile navigation controls">  
-        <!-- Mobile search icon now scrolls to Shop + focuses the ONE shop search input -->  
-        <button id="mobile-search-btn" class="nav-icon-btn" type="button" aria-label="Search shop">  
-          <svg width="20" height="20" fill="currentColor" viewBox="0 0 24 24" aria-hidden="true">  
-            <path  
-              d="M10 2a8 8 0 105.293 14.293l4.707 4.707a1 1 0 001.414-1.414l-4.707-4.707A8 8 0 0010 2zm0 2a6 6 0 110 12 6 6 0 010-12z"  
-            />  
-          </svg>  
-        </button>  
-  
-        <button  
-          id="mobile-menu-btn"  
-          class="nav-icon-btn"  
-          type="button"  
-          aria-label="Open menu"  
-          aria-expanded="false"  
-          aria-controls="mobile-menu-panel"  
-        >  
-          <span class="hamburger" aria-hidden="true">  
-            <span></span><span></span><span></span>  
-          </span>  
-        </button>  
-      </div>  
-    </nav>  
+    <div class="shipping-strip" role="status" aria-live="polite">Free shipping for orders over 1000</div>
+
+    <nav class="navbar" id="navbar">
+      <button
+        id="mobile-menu-btn"
+        class="nav-icon-btn nav-menu-btn"
+        type="button"
+        aria-label="Open menu"
+        aria-expanded="false"
+        aria-controls="mobile-menu-panel"
+      >
+        <span class="hamburger" aria-hidden="true">
+          <span></span><span></span><span></span>
+        </span>
+      </button>
+
+      <a href="#drop" aria-label="FAIDE Home" class="brand-link">
+        <img src="images/faide-wordmark.png" alt="FAIDE" class="faide-wordmark-img" id="brand-wordmark" loading="eager" decoding="async" fetchpriority="high" />
+      </a>
+
+      <div class="nav-links" aria-label="Primary navigation">
+        <a href="#drop" data-nav-link="main">NEW DROP</a>
+        <a href="#lookbook" data-nav-link="main">LOOKBOOK</a>
+        <a href="#shop" data-nav-link="main">SHOP</a>
+        <a href="#about" data-nav-link="main">ABOUT</a>
+      </div>
+
+      <div class="nav-right-actions" aria-label="Nav quick actions">
+        <button id="mobile-search-btn" class="nav-icon-btn nav-search-btn" type="button" aria-label="Search shop">
+          <svg width="20" height="20" fill="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+            <path d="M10 2a8 8 0 105.293 14.293l4.707 4.707a1 1 0 001.414-1.414l-4.707-4.707A8 8 0 0010 2zm0 2a6 6 0 110 12 6 6 0 010-12z"/>
+          </svg>
+        </button>
+
+        <button id="nav-cart-btn" class="nav-icon-btn nav-cart-btn" aria-label="View shopping bag" type="button">
+          <svg width="21" height="21" fill="none" stroke="currentColor" stroke-width="1.9" viewBox="0 0 24 24" aria-hidden="true">
+            <path d="M6 8h12l-1.1 11H7.1L6 8Z" />
+            <path d="M9 8V6a3 3 0 0 1 6 0v2" />
+          </svg>
+          <span id="cart-count" class="cart-count cart-count-nav">0</span>
+        </button>
+      </div>
+    </nav>
   
     <!-- Mobile menu side drawer + overlay -->  
     <div id="mobile-drawer-overlay" class="drawer-overlay" aria-hidden="true"></div>  
@@ -267,12 +274,12 @@
         <div class="hero-bg" aria-hidden="true"></div>  
   
         <div class="hero-content">  
-          <h2 class="hero-title fade-in-up delay-1" id="hero-title">NEW DROP</h2>  
-          <p class="hero-text fade-in-up delay-2" id="hero-description">  
+          <h2 class="hero-title" id="hero-title">NEW DROP</h2>  
+          <p class="hero-text" id="hero-description">  
             New drops, exclusive releases, and updates are announced on our social platforms.  
           </p>  
   
-          <div class="hero-social-icons fade-in-up delay-2">  
+          <div class="hero-social-icons">  
             <a  
               href="https://www.instagram.com/faideclothing"  
               target="_blank"  
@@ -324,7 +331,7 @@
             </a>  
           </div>  
   
-          <button class="primary-btn fade-in-up delay-3" id="shop-now-btn">Shop Now</button>  
+          <button class="primary-btn" id="shop-now-btn">Shop Now</button>  
         </div>  
       </section>  
   
@@ -406,7 +413,7 @@
       <div class="modal-card modal-card-policy">  
         <div class="modal-head">  
           <div>
-            <div class="modal-eyebrow">Store policy</div>
+            
             <h2 id="modal-title" class="modal-title">Policy</h2>
           </div>
   
@@ -426,16 +433,7 @@
     <!-- CART -->  
     <div id="cart-overlay" class="cart-overlay" aria-hidden="true"></div>  
   
-    <button id="floating-cart" class="floating-cart" aria-label="View shopping cart" type="button">  
-      <svg width="24" height="24" fill="currentColor" viewBox="0 0 24 24" aria-hidden="true">  
-        <path  
-          d="M10 19.5c0 .829-.672 1.5-1.5 1.5s-1.5-.671-1.5-1.5c0-.828.672-1.5 1.5-1.5s1.5.672 1.5 1.5zm3.5-1.5c-.828 0-1.5.671-1.5 1.5s.672 1.5 1.5 1.5 1.5-.671 1.5-1.5c0-.828-.672-1.5-1.5-1.5zm6.304-15l-3.431 12h-2.102l2.542-9h-16.813l4.615 11h13.239l3.474-12h1.929l.743-2h-4.196z"  
-        />  
-      </svg>  
-      <span id="cart-count" class="cart-count">0</span>  
-    </button>  
-  
-    <div id="cart-sidebar" class="cart-sidebar" aria-label="Shopping cart">  
+        <div id="cart-sidebar" class="cart-sidebar" aria-label="Shopping cart">  
       <div class="cart-header">
         <div>
           <div class="cart-kicker">FAIDE Bag</div>
@@ -453,8 +451,8 @@
   
       <div class="cart-panel-intro">
         <div class="cart-intro-card">
-          <div class="cart-intro-title">Secure your pieces</div>
-          <div class="cart-intro-text">Review sizes, colours, and quantities before you save your checkout details.</div>
+          <div class="cart-intro-title">Review bag</div>
+          <div class="cart-intro-text">Sizes and quantity.</div>
         </div>
       </div>
 
@@ -465,7 +463,7 @@
           <span class="cart-total-label">Estimated total</span>  
           <span class="cart-total-value">R<span id="cart-total">0.00</span></span>  
         </div>  
-        <div class="cart-footer-note">Shipping and payment confirmation are arranged after your details are saved.</div>
+        <div class="cart-footer-note">Shipping confirmed after details are saved.</div>
         <button class="checkout-btn" id="checkout-btn" type="button" disabled title="Add items to checkout">  
           Continue to Checkout  
         </button>  
@@ -567,7 +565,7 @@
       aria-labelledby="signup-title"  
       style="display:none;"  
     >  
-      <div class="modal-card">  
+      <div class="modal-card signup-modal-card">  
         <div class="modal-head">  
           <h2 id="signup-title" class="modal-title">Join FAIDE</h2>  
   


### PR DESCRIPTION
### Motivation
- Add a persistent shipping message and simplify the header layout for a centered brand and compact nav controls. 
- Remove scroll-based reveal/fade animations for a more immediate UI and better accessibility. 
- Provide a local signup/login experience that persists accounts on-device and surface clearer stock/cart copy. 

### Description
- Added a fixed `.shipping-strip` and updated `.navbar` layout and related CSS rules in `public/assets/css/style.css` to center the brand, move nav controls, remove decorative fades, and tweak responsive sizes. 
- Introduced `route-open` body state in `public/assets/js/app.js` and changed route handling to hide the navbar/shipping strip for routed product/lookbook views. 
- Reworked signup/login to persist users in localStorage with a new `USERS_KEY` and updated auth flow to create/find users and save `AUTH_KEY`/`SIGNUP_KEY` on success. 
- Updated product stock messages, product button labels, cart copy, and small UI text tweaks, and adjusted the shop render (button label changed to "Sold out", stock messages to "In stock"/"Out"); also added a new product (`tracksuit`) and restructured `products.json`. 
- Replaced the floating cart element with a nav cart button (`nav-cart-btn`), updated references in `index.html` and `app.js`, and changed some modal/markup attributes and class names (e.g. `signup-modal-card`). 
- Disabled reveal animations by short-circuiting `initRevealAnimations()` and removing animation/transitions for targeted classes in CSS. 

### Testing
- No automated tests were added or executed for these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c3947ff2b88325935475b06fe73eb8)