### PR TITLE
Refine navbar UI, left-side drawer, and product modal fixes

### DIFF
--- a/public/assets/css/style.css
+++ b/public/assets/css/style.css
@@ -178,18 +178,18 @@ body.nav-hidden #navbar {
 .drawer {
   position: fixed;
   top: 0;
-  right: -320px;
+  left: -320px;
   width: 320px;
   height: 100%;
   background: #0a0a0a;
   z-index: 1300;
-  border-left: 1px solid rgba(255,255,255,0.08);
-  box-shadow: -8px 0 30px rgba(0,0,0,0.7);
-  transition: right 0.28s ease;
+  border-right: 1px solid rgba(255,255,255,0.08);
+  box-shadow: 8px 0 30px rgba(0,0,0,0.7);
+  transition: left 0.28s ease;
   display: flex;
   flex-direction: column;
 }
-.drawer.open { right:0; }
+.drawer.open { left:0; }
 .drawer-head {
   display:flex;
   align-items:center;
@@ -1364,7 +1364,7 @@ body.nav-hidden #navbar {
 @media (max-width: 768px) {
   .drawer {
     width: min(92vw, 360px);
-    right: calc(-1 * min(92vw, 360px));
+    left: calc(-1 * min(92vw, 360px));
   }
 
   .drawer-auth-actions {
@@ -1387,7 +1387,7 @@ body.nav-hidden #navbar {
 }
 
 .policy-body {
-  background: linear-gradient(180deg, rgba(255,255,255,0.02), rgba(255,255,255,0));
+  background: none;
 }
 
 .policy-stack {
@@ -1851,8 +1851,8 @@ body.nav-hidden #navbar {
   text-transform: uppercase;
   padding: 8px 12px;
   color: #fff;
-  background: rgba(0, 0, 0, 0.72);
-  border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+  background: #7a7a7a;
+  border-bottom: none;
 }
 
 .navbar {
@@ -1861,7 +1861,7 @@ body.nav-hidden #navbar {
   backdrop-filter: none !important;
   border-bottom: none !important;
   display: grid;
-  grid-template-columns: 44px 1fr 44px;
+  grid-template-columns: 44px 1fr auto;
   align-items: center;
 }
 
@@ -1881,7 +1881,26 @@ body.nav-hidden #navbar {
 }
 
 .nav-menu-btn { justify-self: start; }
-.nav-cart-btn { justify-self: end; position: relative; }
+.nav-right-actions {
+  justify-self: end;
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+}
+.nav-cart-btn { position: relative; }
+.nav-icon-btn {
+  border: none;
+  background: transparent;
+  border-radius: 0;
+  width: 36px;
+  height: 36px;
+}
+.nav-icon-btn:hover,
+.nav-icon-btn:active {
+  background: transparent;
+  border-color: transparent;
+  transform: none;
+}
 .cart-count-nav {
   width: 18px;
   height: 18px;
@@ -1893,6 +1912,9 @@ body.nav-hidden #navbar {
 
 .hero {
   padding-top: calc(var(--nav-h) + 130px);
+}
+.hero-bg::after {
+  background: none;
 }
 
 .route-page {
@@ -1941,6 +1963,7 @@ body.route-open .shipping-strip {
 
   .navbar {
     top: 32px;
+    grid-template-columns: 40px 1fr auto;
   }
 }
 

--- a/public/assets/js/app.js
+++ b/public/assets/js/app.js
@@ -704,7 +704,7 @@
                 <button type="button" class="qty-btn-ui" data-qty-btn="inc" aria-label="Increase quantity">+</button>
               </div>
             </div>
-            <button type="button" class="secondary-btn add-to-cart" ${available ? "disabled" : "disabled data-disabled-reason=\"out-of-stock\""}>${available ? "Add to Bag" : "Sold out"}</button>
+            <button type="button" class="secondary-btn add-to-cart" ${available ? "" : "disabled data-disabled-reason=\"out-of-stock\""}>${available ? "Add to Bag" : "Sold out"}</button>
           </div>
         </div>`;
       shopEl.appendChild(card);
@@ -721,6 +721,7 @@
     const navbar = document.querySelector(".navbar");
     const navLinks = document.querySelectorAll('[data-nav-link="main"]');
     const menuBtn = $("mobile-menu-btn");
+    const navSearchBtn = $("nav-search-btn");
     const drawer = $("mobile-menu-panel");
     const drawerOverlay = $("mobile-drawer-overlay");
     const shopSearchInput = $("shop-search-input");
@@ -767,6 +768,13 @@
     shopSearchClear?.addEventListener("click", () => {
       setSearchValue("");
       shopSearchInput?.focus();
+    });
+    navSearchBtn?.addEventListener("click", () => {
+      if (activeRoute) gotoHomeSection("shop");
+      setTimeout(() => {
+        scrollToSectionId("shop");
+        shopSearchInput?.focus();
+      }, 30);
     });
 
     initPolicies();
@@ -1158,6 +1166,7 @@
       if (page === "product") {
         showRoute("product");
         renderProductRoute(productId);
+        window.scrollTo({ top: 0, behavior: "auto" });
         return;
       }
       showRoute(null);

--- a/public/index.html
+++ b/public/index.html
@@ -129,12 +129,21 @@
         <a href="#about" data-nav-link="main">ABOUT</a>
       </div>
 
-      <button id="nav-cart-btn" class="nav-icon-btn nav-cart-btn" aria-label="View shopping cart" type="button">
-        <svg width="22" height="22" fill="currentColor" viewBox="0 0 24 24" aria-hidden="true">
-          <path d="M10 19.5c0 .829-.672 1.5-1.5 1.5s-1.5-.671-1.5-1.5c0-.828.672-1.5 1.5-1.5s1.5.672 1.5 1.5zm3.5-1.5c-.828 0-1.5.671-1.5 1.5s.672 1.5 1.5 1.5 1.5-.671 1.5-1.5c0-.828-.672-1.5-1.5-1.5zm6.304-15l-3.431 12h-2.102l2.542-9h-16.813l4.615 11h13.239l3.474-12h1.929l.743-2h-4.196z"/>
-        </svg>
-        <span id="cart-count" class="cart-count cart-count-nav">0</span>
-      </button>
+      <div class="nav-right-actions" aria-label="Search and cart">
+        <button id="nav-search-btn" class="nav-icon-btn nav-search-btn" aria-label="Search products" type="button">
+          <svg width="20" height="20" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24" aria-hidden="true">
+            <circle cx="11" cy="11" r="7"></circle>
+            <line x1="16.65" y1="16.65" x2="21" y2="21"></line>
+          </svg>
+        </button>
+        <button id="nav-cart-btn" class="nav-icon-btn nav-cart-btn" aria-label="View shopping bag" type="button">
+          <svg width="22" height="22" fill="none" stroke="currentColor" stroke-width="1.9" viewBox="0 0 24 24" aria-hidden="true">
+            <path d="M7 8V7a5 5 0 0 1 10 0v1" stroke-linecap="round" stroke-linejoin="round"></path>
+            <path d="M5.2 8.4h13.6l-1.1 11.4H6.3L5.2 8.4z" stroke-linejoin="round"></path>
+          </svg>
+          <span id="cart-count" class="cart-count cart-count-nav">0</span>
+        </button>
+      </div>
     </nav>
   
     <!-- Mobile menu side drawer + overlay -->  
@@ -404,7 +413,6 @@
       <div class="modal-card modal-card-policy">  
         <div class="modal-head">  
           <div>
-            <div class="modal-eyebrow">Store policy</div>
             <h2 id="modal-title" class="modal-title">Policy</h2>
           </div>
   


### PR DESCRIPTION
### Motivation
- Refresh the top-of-page chrome and navbar controls to match requested styling and UX (specific color, search icon placement, and cart/bag visuals). 
- Make the mobile menu behave as expected by sliding in from the left rather than the right. 
- Eliminate subtle visual fades/overlays and remove redundant policy header text to reduce visual clutter. 
- Fix UI logic bugs that prevented in-stock products from being added to the bag and improve mobile product-route behavior.

### Description
- Updated the shipping strip color to `#7a7a7a` and removed its bottom border to match the requested look. 
- Restored a dedicated navbar search button and replaced the previous cart glyph with a cleaner shopping bag icon, grouping both actions in a right-side action cluster. 
- Removed the circular highlight/hover styling for desktop nav icons by simplifying `.nav-icon-btn` rules so desktop icons no longer show the circular highlight. 
- Reworked the mobile drawer CSS so the drawer is positioned/animated from the left (`left: -320px` / `.drawer.open { left:0 }`) and updated the mobile override to match. 
- Removed the eyebrow text "Store policy" from the policy modal header and cleared faded overlay gradients by setting `hero-bg::after` and `.policy-body` backgrounds to `none`. 
- Fixed shop card logic so the Add to Bag button is enabled for available products by changing the rendered `disabled` attribute logic in the shop card template. 
- Wired the added navbar search button to focus/scroll to the shop search input, and added a small route fix to scroll to top when opening the product route on mobile. 
- Changes are confined to `public/index.html`, `public/assets/css/style.css`, and `public/assets/js/app.js`.

### Testing
- Ran `node --check public/assets/js/app.js` which completed without syntax errors. 
- Basic repository status inspection confirmed the three files were modified as expected. 
- No automated visual/UI tests were available in this environment, so rendered UI verification should be validated in a browser (manual QA recommended).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c3a34a5c5c8325b90b2b03ae954706)