### PR TITLE
final update

### DIFF
--- a/public/assets/css/style.css
+++ b/public/assets/css/style.css
@@ -2096,31 +2096,10 @@ body.route-open .shipping-strip {
   cursor: zoom-out;
 }
 
-.lookbook-zoom-hint {
-  position: absolute;
-  bottom: 10px;
-  left: 50%;
-  transform: translateX(-50%);
-  background: rgba(0,0,0,0.64);
-  color: #cfcfcf;
-  border: 1px solid rgba(255,255,255,0.2);
-  border-radius: 999px;
-  padding: 6px 10px;
-  font-size: 0.66rem;
-  letter-spacing: 0.07em;
-  text-transform: uppercase;
-  pointer-events: none;
-  transition: opacity 0.2s ease;
-}
 
 @media (max-width: 768px) {
   .lookbook-view {
     gap: 10px;
     padding: 10px;
-  }
-
-  .lookbook-zoom-hint {
-    font-size: 0.6rem;
-    bottom: 8px;
   }
 }

--- a/public/assets/css/style.css
+++ b/public/assets/css/style.css
@@ -1850,7 +1850,7 @@ body.nav-hidden #navbar {
 }
 
 .navbar {
-  top: 38px;
+  top: 32px;
   background: transparent !important;
   backdrop-filter: none !important;
   border-bottom: 1px solid rgba(255,255,255,0.14) !important;
@@ -1996,7 +1996,7 @@ body.route-open .shipping-strip {
   }
 
   .navbar {
-    top: 36px;
+    top: 31px;
     grid-template-columns: 40px 1fr auto;
   }
 
@@ -2020,5 +2020,107 @@ body.route-open .shipping-strip {
   #mobile-menu-panel,
   #mobile-drawer-overlay {
     display: none !important;
+  }
+}
+
+
+/* ===== Follow-up polish ===== */
+.modal-card-policy {
+  max-width: 680px !important;
+  width: min(680px, calc(100vw - 24px)) !important;
+  max-height: 86vh;
+}
+
+#policy-modal .modal-body {
+  max-height: calc(86vh - 90px);
+  overflow-y: auto;
+}
+
+/* remove faded edge styling from overlays/panels */
+.drawer,
+.signup-modal-card,
+.checkout-modal-card,
+.modal-card,
+.cart-sidebar {
+  box-shadow: none !important;
+  background-image: none !important;
+}
+
+.cart-sidebar,
+.cart-header,
+.cart-footer,
+.cart-intro-card,
+.checkout-banner,
+.checkout-support-card,
+.checkout-summary,
+.checkout-form {
+  background: #101010 !important;
+}
+
+/* smoother and less jittery animations */
+.cart-sidebar.active,
+.modal-card,
+.checkout-step-chip {
+  animation-duration: 0.2s !important;
+  animation-timing-function: ease-out !important;
+}
+
+/* FAIDE gray hamburger look on mobile */
+.hamburger span {
+  background: #8d8d8d;
+}
+
+/* Lookbook modal UI + zoom */
+.lookbook-view {
+  border-radius: 18px;
+  border-color: rgba(255,255,255,0.12);
+  background: #0b0b0b;
+}
+
+.lookbook-image-shell {
+  position: relative;
+  width: 100%;
+  overflow: hidden;
+  border-radius: 14px;
+  border: 1px solid rgba(255,255,255,0.1);
+  background: #000;
+}
+
+.lookbook-view img {
+  touch-action: none;
+  transition: transform 0.2s ease-out;
+  transform-origin: center center;
+}
+
+.lookbook-view img.zoomed {
+  cursor: zoom-out;
+}
+
+.lookbook-zoom-hint {
+  position: absolute;
+  bottom: 10px;
+  left: 50%;
+  transform: translateX(-50%);
+  background: rgba(0,0,0,0.64);
+  color: #cfcfcf;
+  border: 1px solid rgba(255,255,255,0.2);
+  border-radius: 999px;
+  padding: 6px 10px;
+  font-size: 0.66rem;
+  letter-spacing: 0.07em;
+  text-transform: uppercase;
+  pointer-events: none;
+  transition: opacity 0.2s ease;
+}
+
+@media (max-width: 768px) {
+  .lookbook-view {
+    gap: 10px;
+    padding: 10px;
+  }
+
+  .lookbook-zoom-hint {
+    font-size: 0.6rem;
+    bottom: 8px;
   }
 }

--- a/public/assets/css/style.css
+++ b/public/assets/css/style.css
@@ -181,7 +181,7 @@ body.nav-hidden #navbar {
   left: -320px;
   width: 320px;
   height: 100%;
-  background: #0a0a0a;
+  background: #707070;
   z-index: 1300;
   border-right: 1px solid rgba(255,255,255,0.08);
   box-shadow: 8px 0 30px rgba(0,0,0,0.7);
@@ -1060,7 +1060,7 @@ body.nav-hidden #navbar {
 .modal-card {
   max-width: 820px;
   margin: 0 auto;
-  background: #0a0a0a;
+  background: #707070;
   border-radius: 20px;
   border: 1px solid var(--border);
   overflow: hidden;
@@ -1243,7 +1243,7 @@ body.nav-hidden #navbar {
   align-items: center;
   gap: 8px;
   border-radius: 999px;
-  font-size: 0.72rem;
+  font-size: 0.78rem;
   font-weight: 800;
   letter-spacing: 0.06em;
   text-transform: uppercase;
@@ -1352,7 +1352,7 @@ body.nav-hidden #navbar {
 
 .rpp-stock {
   margin-top: 14px;
-  padding: 8px 12px;
+  padding: 10px 12px;
 }
 
 @media (max-width: 768px) {
@@ -1371,7 +1371,7 @@ body.nav-hidden #navbar {
   color: #9ca3af;
   text-transform: uppercase;
   letter-spacing: 0.18em;
-  font-size: 0.72rem;
+  font-size: 0.78rem;
   font-weight: 800;
   margin-bottom: 8px;
 }
@@ -1703,7 +1703,7 @@ body.nav-hidden #navbar {
 
 .checkout-step-chip {
   border-radius: 999px;
-  padding: 8px 12px;
+  padding: 10px 12px;
   background: rgba(255,255,255,0.06);
   border: 1px solid rgba(255,255,255,0.08);
   color: #fff;
@@ -1840,20 +1840,20 @@ body.nav-hidden #navbar {
   right: 0;
   z-index: 1100;
   text-align: center;
-  font-size: 0.72rem;
+  font-size: 0.78rem;
   letter-spacing: 0.08em;
   text-transform: uppercase;
-  padding: 8px 12px;
+  padding: 10px 12px;
   color: #fff;
-  background: #0a0a0a;
+  background: #707070;
   border-bottom: none;
 }
 
 .navbar {
-  top: 34px;
-  background: #000 !important;
-  backdrop-filter: blur(6px) !important;
-  border-bottom: 1px solid rgba(255,255,255,0.08) !important;
+  top: 38px;
+  background: transparent !important;
+  backdrop-filter: none !important;
+  border-bottom: 1px solid rgba(255,255,255,0.14) !important;
   display: grid;
   grid-template-columns: 44px 1fr auto;
   align-items: center;
@@ -1889,18 +1889,19 @@ body.nav-hidden #navbar {
 }
 .nav-cart-btn { position: relative; }
 .nav-icon-btn {
-  border: 1px solid rgba(122,122,122,0.35);
+  border: none;
   background: transparent;
-  color: #7a7a7a;
-  border-radius: 999px;
-  width: 36px;
-  height: 36px;
+  color: #d4d4d4;
+  border-radius: 0;
+  width: 34px;
+  height: 34px;
 }
 .nav-icon-btn:hover,
 .nav-icon-btn:active {
   background: transparent;
   border-color: transparent;
   transform: none;
+  color: #ffffff;
 }
 .cart-count-nav {
   width: 18px;
@@ -1955,7 +1956,7 @@ body.route-open .shipping-strip {
 .lookbook-card { height: 420px; }
 .modal-card { max-width: 760px; }
 .modal-card-policy { max-width: 760px; width: min(760px, calc(100vw - 48px)); }
-.checkout-modal-card { max-width: 920px; width: min(920px, calc(100vw - 48px)); }
+.checkout-modal-card { max-width: 860px; width: min(860px, calc(100vw - 36px)); max-height: min(88vh, 860px); }
 
 .qty-stepper-inner {
   display: inline-flex;
@@ -1995,8 +1996,16 @@ body.route-open .shipping-strip {
   }
 
   .navbar {
-    top: 32px;
+    top: 36px;
     grid-template-columns: 40px 1fr auto;
+  }
+
+
+  .checkout-modal-card {
+    width: min(94vw, 680px);
+    max-width: min(94vw, 680px);
+    max-height: 88vh;
+    margin-top: 6vh;
   }
 
   .nav-links {

--- a/public/assets/js/app.js
+++ b/public/assets/js/app.js
@@ -15,7 +15,7 @@
 
   const defaultConfig = {
     brand_name: "FAIDE",
-    hero_title: "NEW DROP",
+    hero_title: "HOME",
     hero_description: "New drops, exclusive releases, and updates are announced on our social platforms.",
     about_headline: "About FAIDE",
     about_description:
@@ -105,6 +105,20 @@
     const res = await fetch(url, { cache: "no-store" });
     if (!res.ok) throw new Error("Failed to load products.json");
     return res.json();
+  }
+
+  function optimizeImageLoading() {
+    const images = document.querySelectorAll("img");
+    images.forEach((img) => {
+      if (!img.hasAttribute("decoding")) img.setAttribute("decoding", "async");
+      if (img.id === "brand-wordmark") return;
+      if (img.closest(".hero") && !img.hasAttribute("fetchpriority")) {
+        img.setAttribute("fetchpriority", "high");
+        if (!img.hasAttribute("loading")) img.setAttribute("loading", "eager");
+        return;
+      }
+      if (!img.hasAttribute("loading")) img.setAttribute("loading", "lazy");
+    });
   }
 
   function getNavOffsetPx() {
@@ -600,6 +614,15 @@
     });
     switchBtn?.addEventListener("click", () => setMode(mode === "login" ? "signup" : "login"));
 
+    [email, password].forEach((field) => {
+      field?.addEventListener("keydown", (e) => {
+        if (e.key === "Enter") {
+          e.preventDefault();
+          submit?.click();
+        }
+      });
+    });
+
     submit?.addEventListener("click", () => {
       const userEmail = email?.value?.trim() || "";
       const userPassword = password?.value?.trim() || "";
@@ -609,7 +632,7 @@
       }
       const users = loadJsonStorage(USERS_KEY, []);
       if (mode === "signup") {
-        if (users.some((u) => u.email === userEmail)) {
+        if (users.some((u) => u.email.toLowerCase() === userEmail.toLowerCase())) {
           showCartToast("Email already registered. Log in instead.");
           return;
         }
@@ -619,7 +642,7 @@
         saveJsonStorage(AUTH_KEY, { email: userEmail, ts: Date.now() });
         showCartToast("You’re in. Account saved on this device.");
       } else {
-        const match = users.find((u) => u.email === userEmail && u.password === userPassword);
+        const match = users.find((u) => u.email.toLowerCase() === userEmail.toLowerCase() && u.password === userPassword);
         if (!match) {
           showCartToast("Account not found. Check details or sign up.");
           return;
@@ -743,6 +766,7 @@
     const navLinks = document.querySelectorAll('[data-nav-link="main"]');
     const menuBtn = $("mobile-menu-btn");
     const navSearchBtn = $("nav-search-btn");
+    const navLoginBtn = $("nav-login-btn");
     const drawer = $("mobile-menu-panel");
     const drawerOverlay = $("mobile-drawer-overlay");
     const shopSearchInput = $("shop-search-input");
@@ -823,6 +847,10 @@
       closeOverlay("drawer");
       authModal.openSignup();
     });
+    navLoginBtn?.addEventListener("click", (e) => {
+      e.preventDefault();
+      authModal.openLogin();
+    });
 
     try {
       catalog = await loadCatalog();
@@ -838,6 +866,7 @@
     renderLookbook($("lookbook-list"), catalog.lookbook || []);
     renderShop($("shop-products"), catalog.products || [], catalog.settings || {});
     initRevealAnimations();
+    optimizeImageLoading();
 
     const floatingCart = $("nav-cart-btn");
     const cartSidebar = $("cart-sidebar");

--- a/public/assets/js/app.js
+++ b/public/assets/js/app.js
@@ -1117,13 +1117,11 @@
     let pinchStartDistance = 0;
     let pinchStartScale = 1;
     const pointerMap = new Map();
-    const zoomHint = $("lookbook-zoom-hint");
 
     function applyLookbookTransform() {
       if (!rlbImg) return;
       rlbImg.style.transform = `translate(${lookbookX}px, ${lookbookY}px) scale(${lookbookScale})`;
       rlbImg.classList.toggle("zoomed", lookbookScale > 1.01);
-      if (zoomHint) zoomHint.style.opacity = lookbookScale > 1.01 ? "0" : "0.78";
     }
 
     function resetLookbookZoom() {

--- a/public/assets/js/app.js
+++ b/public/assets/js/app.js
@@ -319,7 +319,7 @@
     if (overlayRegistry.get(name)?.isOpen()) return;
     overlayRegistry.get(name)?.open();
     overlayHistory.push(name);
-    if (isMobile()) history.pushState({ __faideOverlay: name }, "");
+    history.pushState({ __faideOverlay: name }, "");
     refreshPageLocks();
   }
 
@@ -329,7 +329,7 @@
     const index = overlayHistory.lastIndexOf(name);
     if (index >= 0) overlayHistory.splice(index, 1);
     refreshPageLocks();
-    if (isMobile() && !fromPop && history.state?.__faideOverlay === name) {
+    if (!fromPop && history.state?.__faideOverlay === name) {
       history.back();
     }
     return true;
@@ -1108,7 +1108,83 @@
         rlbImg.decoding = "async";
       }
       if (rlbMeta) rlbMeta.textContent = `Look ${safeIdx} of ${total}`;
+      resetLookbookZoom();
     }
+
+    let lookbookScale = 1;
+    let lookbookX = 0;
+    let lookbookY = 0;
+    let pinchStartDistance = 0;
+    let pinchStartScale = 1;
+    const pointerMap = new Map();
+    const zoomHint = $("lookbook-zoom-hint");
+
+    function applyLookbookTransform() {
+      if (!rlbImg) return;
+      rlbImg.style.transform = `translate(${lookbookX}px, ${lookbookY}px) scale(${lookbookScale})`;
+      rlbImg.classList.toggle("zoomed", lookbookScale > 1.01);
+      if (zoomHint) zoomHint.style.opacity = lookbookScale > 1.01 ? "0" : "0.78";
+    }
+
+    function resetLookbookZoom() {
+      lookbookScale = 1;
+      lookbookX = 0;
+      lookbookY = 0;
+      applyLookbookTransform();
+    }
+
+    function getPointerDistance() {
+      const points = Array.from(pointerMap.values());
+      if (points.length < 2) return 0;
+      const dx = points[0].x - points[1].x;
+      const dy = points[0].y - points[1].y;
+      return Math.hypot(dx, dy);
+    }
+
+    rlbImg?.addEventListener("dblclick", () => {
+      if (lookbookScale > 1.01) resetLookbookZoom();
+      else {
+        lookbookScale = 1.9;
+        applyLookbookTransform();
+      }
+    });
+
+    rlbImg?.addEventListener("pointerdown", (e) => {
+      pointerMap.set(e.pointerId, { x: e.clientX, y: e.clientY });
+      if (pointerMap.size === 2) {
+        pinchStartDistance = getPointerDistance();
+        pinchStartScale = lookbookScale;
+      }
+    });
+
+    rlbImg?.addEventListener("pointermove", (e) => {
+      if (!pointerMap.has(e.pointerId)) return;
+      const prev = pointerMap.get(e.pointerId);
+      pointerMap.set(e.pointerId, { x: e.clientX, y: e.clientY });
+
+      if (pointerMap.size === 2) {
+        const currentDistance = getPointerDistance();
+        if (pinchStartDistance > 0) {
+          lookbookScale = Math.min(3, Math.max(1, pinchStartScale * (currentDistance / pinchStartDistance)));
+          applyLookbookTransform();
+        }
+        return;
+      }
+
+      if (lookbookScale > 1.01 && prev) {
+        lookbookX += e.clientX - prev.x;
+        lookbookY += e.clientY - prev.y;
+        applyLookbookTransform();
+      }
+    });
+
+    ["pointerup", "pointercancel", "pointerleave"].forEach((eventName) => {
+      rlbImg?.addEventListener(eventName, (e) => {
+        pointerMap.delete(e.pointerId);
+        if (pointerMap.size < 2) pinchStartDistance = 0;
+        if (lookbookScale <= 1.01) resetLookbookZoom();
+      });
+    });
 
     function setRppImage(i) {
       if (!rppSources.length || !rpp.img) return;

--- a/public/index.html
+++ b/public/index.html
@@ -206,7 +206,6 @@
           <button type="button" class="route-arrow route-arrow-left" id="rlb-prev" aria-label="Previous lookbook image">‹</button>
           <div class="lookbook-image-shell">
             <img id="rlb-img" alt="Lookbook image" src="" />
-            <div class="lookbook-zoom-hint" id="lookbook-zoom-hint">Pinch or double tap to zoom</div>
           </div>
           <button type="button" class="route-arrow route-arrow-right" id="rlb-next" aria-label="Next lookbook image">›</button>
         </div>

--- a/public/index.html
+++ b/public/index.html
@@ -123,13 +123,19 @@
       </a>
 
       <div class="nav-links" aria-label="Primary navigation">
-        <a href="#drop" data-nav-link="main">NEW DROP</a>
+        <a href="#drop" data-nav-link="main">HOME</a>
         <a href="#lookbook" data-nav-link="main">LOOKBOOK</a>
         <a href="#shop" data-nav-link="main">SHOP</a>
         <a href="#about" data-nav-link="main">ABOUT</a>
       </div>
 
-      <div class="nav-right-actions" aria-label="Search and cart">
+      <div class="nav-right-actions" aria-label="Account, search and cart">
+        <button id="nav-login-btn" class="nav-icon-btn nav-login-btn" aria-label="Log in or sign up" type="button">
+          <svg width="20" height="20" fill="none" stroke="currentColor" stroke-width="1.9" viewBox="0 0 24 24" aria-hidden="true">
+            <circle cx="12" cy="8" r="4"></circle>
+            <path d="M4.5 19.2a8 8 0 0 1 15 0" stroke-linecap="round"></path>
+          </svg>
+        </button>
         <button id="nav-search-btn" class="nav-icon-btn nav-search-btn" aria-label="Search products" type="button">
           <svg width="20" height="20" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24" aria-hidden="true">
             <circle cx="11" cy="11" r="7"></circle>
@@ -162,7 +168,7 @@
       </div>  
   
       <div class="drawer-links">
-        <a href="#drop" data-nav-link="main">NEW DROP</a>
+        <a href="#drop" data-nav-link="main">HOME</a>
         <a href="#lookbook" data-nav-link="main">LOOKBOOK</a>
         <a href="#shop" data-nav-link="main">SHOP</a>
         <a href="#about" data-nav-link="main">ABOUT</a>
@@ -274,7 +280,7 @@
         <div class="hero-bg" aria-hidden="true"></div>  
   
         <div class="hero-content">  
-          <h2 class="hero-title" id="hero-title">NEW DROP</h2>  
+          <h2 class="hero-title" id="hero-title">HOME</h2>  
           <p class="hero-text" id="hero-description">  
             New drops, exclusive releases, and updates are announced on our social platforms.  
           </p>  

--- a/public/index.html
+++ b/public/index.html
@@ -204,7 +204,10 @@
   
         <div class="lookbook-view">  
           <button type="button" class="route-arrow route-arrow-left" id="rlb-prev" aria-label="Previous lookbook image">‹</button>
-          <img id="rlb-img" alt="Lookbook image" src="" />  
+          <div class="lookbook-image-shell">
+            <img id="rlb-img" alt="Lookbook image" src="" />
+            <div class="lookbook-zoom-hint" id="lookbook-zoom-hint">Pinch or double tap to zoom</div>
+          </div>
           <button type="button" class="route-arrow route-arrow-right" id="rlb-next" aria-label="Next lookbook image">›</button>
         </div>
         <div class="route-meta" id="rlb-meta"></div>  


### PR DESCRIPTION
### Motivation
- Make the top strip above the navbar a softer grey and slightly larger so it reads better above the page.  
- Make the navbar transparent and remove circular chrome around header icons to simplify header visuals.  
- Surface a desktop login/account control next to search/cart and ensure signup/login works reliably.  
- Improve perceived image load performance and fix checkout modal sizing issues on desktop and mobile.

### Description
- Replaced `NEW DROP` with `HOME` in main nav and updated the hero default title to `HOME` in `public/index.html`.  
- Added a desktop account/login icon button to the right-side nav and wired it to open the existing auth modal in `public/index.html` and `public/assets/js/app.js`.  
- Implemented image-loading optimization: an `optimizeImageLoading()` pass in `public/assets/js/app.js` that sets `decoding="async"`, applies `loading="eager"`/`fetchpriority="high"` to hero images and `loading="lazy"` for non-critical images, and runs after render.  
- Improved auth UX in `public/assets/js/app.js` by adding Enter-key submit handlers and making email comparisons case-insensitive for signup/login.  
- Updated CSS in `public/assets/css/style.css` to change the shipping strip color to `#707070`, slightly increase its size/spacing, make the navbar transparent, remove circular borders/background from nav icons, and refine checkout modal width/height behavior for desktop and mobile.  
- Adjusted other small spacing/font-size tweaks related to the above changes.

### Testing
- Ran `node --check public/assets/js/app.js` to validate the modified JS and it completed successfully.  
- Performed automated grep/status checks with `git status --short && rg -n "HOME|nav-login-btn|shipping-strip|checkout-modal-card|optimizeImageLoading|navLoginBtn|top: 38px|border: none;"` and confirmed the expected changes are present.  
- No browser visual regression tests were run in this environment (visual verification not available here).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c3c0b78bcc8325b6ec66f9ec5da708)